### PR TITLE
UIG-188

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory-pr-build.lb.cumuli.be:8081/acd-docker/node:12
+FROM acd-docker.repository.milieuinfo.be/node:12
 
 ARG VERSION
 ARG REPO

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,31 +5,31 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/core": {
-      "version": "7.4.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/core/-/core-7.4.5.tgz",
-      "integrity": "sha1-CB+X6P/KZam0sP3H4nTnA/AAwGo=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/core/-/core-7.5.5.tgz",
+      "integrity": "sha1-F7JobvDWvFj5Y93daKtml1VYLDA=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helpers": "^7.4.4",
-        "@babel/parser": "^7.4.5",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helpers": "^7.5.5",
+        "@babel/parser": "^7.5.5",
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.5",
-        "@babel/types": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -37,7 +37,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -46,34 +46,34 @@
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.0.tgz",
           "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
     "@babel/generator": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/generator/-/generator-7.4.4.tgz",
-      "integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha1-hzp/k2o8iUkbQ1NtEiRbYmZk488=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4",
+        "@babel/types": "^7.5.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -81,7 +81,7 @@
     },
     "@babel/helper-annotate-as-pure": {
       "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha1-Mj053QtQ4Qx8Bsp9djjmhk2MXDI=",
       "dev": true,
       "requires": {
@@ -90,7 +90,7 @@
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
       "version": "7.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
       "integrity": "sha1-a2lijf5Ah3mODE7Zjj1Kay+9L18=",
       "dev": true,
       "requires": {
@@ -100,7 +100,7 @@
     },
     "@babel/helper-call-delegate": {
       "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
       "integrity": "sha1-h8H4yhmtVSpzanonscH8+LH/H0M=",
       "dev": true,
       "requires": {
@@ -110,19 +110,19 @@
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
-      "integrity": "sha1-aWnR9XC0a9yQDR66jl1ZxIuiwSo=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+      "integrity": "sha1-PewywgRvN+CbKMk+sLED/Sol02k=",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.4.4",
-        "lodash": "^4.17.11"
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
       "integrity": "sha1-U3+hP28WdN90WwwA7I/k6ZaByPY=",
       "dev": true,
       "requires": {
@@ -132,7 +132,7 @@
     },
     "@babel/helper-function-name": {
       "version": "7.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
       "dev": true,
       "requires": {
@@ -143,7 +143,7 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
       "dev": true,
       "requires": {
@@ -152,7 +152,7 @@
     },
     "@babel/helper-hoist-variables": {
       "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
       "integrity": "sha1-Api18lyMCcUxAtUqxKmPdz6yhQo=",
       "dev": true,
       "requires": {
@@ -160,17 +160,17 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-      "integrity": "sha1-jNFLCg33/wDwCefXpDaUX0fHoW8=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+      "integrity": "sha1-H7W47ERTqTxDnun+Ou6kqEt2tZA=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-module-imports": {
       "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha1-lggbcRHkhtpNLNlxrRpP4hbMLj0=",
       "dev": true,
       "requires": {
@@ -178,22 +178,22 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
-      "integrity": "sha1-lhFepCovE55hnpjtRt9gGblEFLg=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+      "integrity": "sha1-+E/4oJA43Lyh/UNVZhpQCTcWW0o=",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
         "@babel/template": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "lodash": "^4.17.11"
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-optimise-call-expression": {
       "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
       "integrity": "sha1-opIMVwKwc8Fd5REGIAqoytIEl9U=",
       "dev": true,
       "requires": {
@@ -202,22 +202,22 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
       "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
-      "integrity": "sha1-pH4CvJH7JZ0uZyfCowAT46wTxKI=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+      "integrity": "sha1-CqaCT3EAouDonBUnwjk2wVLKs1E=",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
       "integrity": "sha1-Nh2AghtvONp1vT8HheziCojF/n8=",
       "dev": true,
       "requires": {
@@ -229,20 +229,20 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
-      "integrity": "sha1-ruQXg+vk8tOrOud14cxvGpDO+ic=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+      "integrity": "sha1-+EzkPfAxIi0rrQaNJibLV5nDS8I=",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
         "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-simple-access": {
       "version": "7.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
       "integrity": "sha1-Ze65VMjCRb6qToWdphiPOdceWFw=",
       "dev": true,
       "requires": {
@@ -252,7 +252,7 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
       "dev": true,
       "requires": {
@@ -261,7 +261,7 @@
     },
     "@babel/helper-wrap-function": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
       "integrity": "sha1-xOABJEV2nigVtVKW6tQ6lYVJ9vo=",
       "dev": true,
       "requires": {
@@ -272,20 +272,20 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helpers/-/helpers-7.4.4.tgz",
-      "integrity": "sha1-hosO9Zwd1OeHRFYtXOG1nIny8qU=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helpers/-/helpers-7.5.5.tgz",
+      "integrity": "sha1-Y5CNKnOUIinR5mhbwqDnMN3jt14=",
       "dev": true,
       "requires": {
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
+      "version": "7.5.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -294,14 +294,14 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha1-BK+NXVorBEoqG/+sweXmZzVE6HI=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/parser/-/parser-7.5.5.tgz",
+      "integrity": "sha1-AvB3rIgX099Kgy71neZ1Zeccyks=",
       "dev": true
     },
     "@babel/plugin-external-helpers": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-external-helpers/-/plugin-external-helpers-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-external-helpers/-/plugin-external-helpers-7.2.0.tgz",
       "integrity": "sha1-f0y33uZRzTgNIDSEfZFCiEZ6a+Q=",
       "dev": true,
       "requires": {
@@ -310,7 +310,7 @@
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
       "integrity": "sha1-somzBmadzkrSCwJSiJoVdoydQX4=",
       "dev": true,
       "requires": {
@@ -320,9 +320,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
-      "integrity": "sha1-HvFz/PJLPi35KmePAnZztV5+MAU=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
+      "integrity": "sha1-YZOXRPcbp2o65Gte6hilTBbSLlg=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -331,7 +331,7 @@
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
       "integrity": "sha1-aeHw2zTG9aDPfiszI78VmnbIy38=",
       "dev": true,
       "requires": {
@@ -340,7 +340,7 @@
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
       "integrity": "sha1-acFZ/69JmBIhYa2OvF5tH1XfhhI=",
       "dev": true,
       "requires": {
@@ -349,7 +349,7 @@
     },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.2.0.tgz",
       "integrity": "sha1-IzPvS4dVU6O80ek/jrwJ9bkhOkA=",
       "dev": true,
       "requires": {
@@ -358,7 +358,7 @@
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
       "dev": true,
       "requires": {
@@ -367,7 +367,7 @@
     },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
       "integrity": "sha1-mur75Nb/xlY7+Pg3IJFijwB3lVA=",
       "dev": true,
       "requires": {
@@ -375,9 +375,9 @@
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
-      "integrity": "sha1-o/HQHy8hytqyCzOoITMRbxT7WJQ=",
+      "version": "7.5.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+      "integrity": "sha1-iaOEigFmYjtbxIEWS1k2q5R+iH4=",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -387,7 +387,7 @@
     },
     "@babel/plugin-transform-block-scoped-functions": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
       "integrity": "sha1-XTzBHo1d3XUqpkyRSNDbbLef0ZA=",
       "dev": true,
       "requires": {
@@ -395,34 +395,34 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
-      "integrity": "sha1-wTJ5+r9rkWZhUxhBojxLfa4pZG0=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
+      "integrity": "sha1-o185XlQCgi8Q0hGfb44EXjY5os4=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
-      "integrity": "sha1-DOQJTNr9cJchB207nDitMcpxXrY=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+      "integrity": "sha1-0JQpnZvWgKFKKg7a44MFrWD7Tek=",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.4.4",
+        "@babel/helper-define-map": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.4.4",
+        "@babel/helper-replace-supers": "^7.5.5",
         "@babel/helper-split-export-declaration": "^7.4.4",
         "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
       "integrity": "sha1-g6ffamWIZbHI9kHVEMbzryICFto=",
       "dev": true,
       "requires": {
@@ -430,18 +430,18 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
-      "integrity": "sha1-nZZHF4KcyeS2AfyCompxpNj68g8=",
+      "version": "7.5.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
+      "integrity": "sha1-9sCf3+P5RRb/B0/od9t7ye8FhVo=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
-      "integrity": "sha1-2VLEkw8xKk2//xjwspFOYMNVMLM=",
+      "version": "7.5.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+      "integrity": "sha1-xdv1EGv4TN9pEiLAl0wSsd+TGFM=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -449,7 +449,7 @@
     },
     "@babel/plugin-transform-exponentiation-operator": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
       "integrity": "sha1-pjhoKJ5bQAf3BU1GSRr1FDV2YAg=",
       "dev": true,
       "requires": {
@@ -459,7 +459,7 @@
     },
     "@babel/plugin-transform-for-of": {
       "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
       "integrity": "sha1-Amf8c14kyAi6FzhmxsTRRA/DxVY=",
       "dev": true,
       "requires": {
@@ -468,7 +468,7 @@
     },
     "@babel/plugin-transform-function-name": {
       "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
       "integrity": "sha1-4UNhFquwYQwiWQlISHVKxSMJIq0=",
       "dev": true,
       "requires": {
@@ -477,9 +477,9 @@
       }
     },
     "@babel/plugin-transform-instanceof": {
-      "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.2.0.tgz",
-      "integrity": "sha1-LuncmzifoTzzJb4Q/4QUvg0Qrs8=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.5.5.tgz",
+      "integrity": "sha1-vTKTqzRlwN+CMsUVEr8kReest0Q=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -487,7 +487,7 @@
     },
     "@babel/plugin-transform-literals": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
       "integrity": "sha1-aQNT6B+SZ9rU/Yz9d+r6hqulPqE=",
       "dev": true,
       "requires": {
@@ -495,28 +495,29 @@
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
-      "integrity": "sha1-gqm85FuVRB9heiQBHcidEtp/TuY=",
+      "version": "7.5.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+      "integrity": "sha1-7wBDXUbaCllhqnKKHS7P8GPk+5E=",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
-      "integrity": "sha1-s11MEPVrq11lAEfa0PHY6IFLZZg=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+      "integrity": "sha1-xwAh34NAc8ZethO4Z5zEo4HRqfk=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0"
+        "@babel/helper-replace-supers": "^7.5.5"
       }
     },
     "@babel/plugin-transform-parameters": {
       "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
       "integrity": "sha1-dVbPA/MYvScZ/kySLS2Ai+VXHhY=",
       "dev": true,
       "requires": {
@@ -527,7 +528,7 @@
     },
     "@babel/plugin-transform-regenerator": {
       "version": "7.4.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
       "integrity": "sha1-Yp3IJRLFXO4BNB+ye9/LIQNUaA8=",
       "dev": true,
       "requires": {
@@ -536,7 +537,7 @@
     },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
       "integrity": "sha1-YzOu4vjW7n4oYVRXKYk0o7RhmPA=",
       "dev": true,
       "requires": {
@@ -545,7 +546,7 @@
     },
     "@babel/plugin-transform-spread": {
       "version": "7.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
       "integrity": "sha1-MQOpq+IvdCttQG7NPNSbd0kZtAY=",
       "dev": true,
       "requires": {
@@ -554,7 +555,7 @@
     },
     "@babel/plugin-transform-sticky-regex": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
       "integrity": "sha1-oeRUtZlVYKnB4NU338FQYf0mh+E=",
       "dev": true,
       "requires": {
@@ -564,7 +565,7 @@
     },
     "@babel/plugin-transform-template-literals": {
       "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
       "integrity": "sha1-nSj+p7vOY3+3YSoHUJidgyHUvLA=",
       "dev": true,
       "requires": {
@@ -574,7 +575,7 @@
     },
     "@babel/plugin-transform-typeof-symbol": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
       "integrity": "sha1-EX0rzsL79ktLWdH5gZiUaC0p8rI=",
       "dev": true,
       "requires": {
@@ -583,7 +584,7 @@
     },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
       "integrity": "sha1-q0Y0u08U02cov1l4Mis1WHeHlw8=",
       "dev": true,
       "requires": {
@@ -594,7 +595,7 @@
     },
     "@babel/template": {
       "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/template/-/template-7.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/template/-/template-7.4.4.tgz",
       "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
       "dev": true,
       "requires": {
@@ -604,25 +605,25 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/traverse/-/traverse-7.4.5.tgz",
-      "integrity": "sha1-TpLRco/S8Yl9r90yHvv/khVsMhY=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/traverse/-/traverse-7.5.5.tgz",
+      "integrity": "sha1-9mT482jtMpiM1kjan3LVynDxZbs=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.5",
-        "@babel/types": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -632,19 +633,19 @@
       }
     },
     "@babel/types": {
-      "version": "7.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
+      "version": "7.5.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha1-l7n3KOGCeFkJqkq1YmTwkKAo0Yo=",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
     },
     "@govflanders/vl-ui-accordion": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-accordion/vl-ui-accordion-3.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-accordion/vl-ui-accordion-3.7.2.tgz",
       "integrity": "sha1-u/4wBm9exjypDSydQ+tF+VyrHM8=",
       "requires": {
         "@govflanders/vl-ui-button": "^3.7.2",
@@ -658,7 +659,7 @@
     },
     "@govflanders/vl-ui-action-group": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-action-group/vl-ui-action-group-3.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-action-group/vl-ui-action-group-3.7.2.tgz",
       "integrity": "sha1-E2/Y8eHuVVT2HB2CocYHXjysbCo=",
       "requires": {
         "@govflanders/vl-ui-button": "^3.7.2",
@@ -669,7 +670,7 @@
     },
     "@govflanders/vl-ui-button": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-button/vl-ui-button-3.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-button/vl-ui-button-3.7.2.tgz",
       "integrity": "sha1-dvwKSntkPitkbpGZNOIIjuie+Js=",
       "requires": {
         "@govflanders/vl-ui-core": "^3.7.2",
@@ -679,7 +680,7 @@
     },
     "@govflanders/vl-ui-core": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-core/vl-ui-core-3.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-core/vl-ui-core-3.7.2.tgz",
       "integrity": "sha1-45te7TkS3m10N6e7kIYe286q3qQ=",
       "requires": {
         "@govflanders/vl-ui-util": "^3.7.2",
@@ -694,7 +695,7 @@
     },
     "@govflanders/vl-ui-form-message": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-form-message/vl-ui-form-message-3.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-form-message/vl-ui-form-message-3.7.2.tgz",
       "integrity": "sha1-nXTJjmQoeQRg7AA/rWab7m1sLkU=",
       "requires": {
         "@govflanders/vl-ui-core": "^3.7.2",
@@ -703,7 +704,7 @@
     },
     "@govflanders/vl-ui-form-structure": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-form-structure/vl-ui-form-structure-3.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-form-structure/vl-ui-form-structure-3.7.2.tgz",
       "integrity": "sha1-a08Yb1sUHCAPETNGzNc/e8ppISE=",
       "requires": {
         "@govflanders/vl-ui-action-group": "^3.7.2",
@@ -717,7 +718,7 @@
     },
     "@govflanders/vl-ui-icon": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-icon/vl-ui-icon-3.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-icon/vl-ui-icon-3.7.2.tgz",
       "integrity": "sha1-Gl838Op4Vk1L02KKIVALzpJHegM=",
       "requires": {
         "@govflanders/vl-ui-core": "^3.7.2",
@@ -726,7 +727,7 @@
     },
     "@govflanders/vl-ui-input-field": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-input-field/vl-ui-input-field-3.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-input-field/vl-ui-input-field-3.7.2.tgz",
       "integrity": "sha1-1OHAsTeig3BkYxrofOM3MYGNOKE=",
       "requires": {
         "@govflanders/vl-ui-button": "^3.7.2",
@@ -737,7 +738,7 @@
     },
     "@govflanders/vl-ui-link": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-link/vl-ui-link-3.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-link/vl-ui-link-3.7.2.tgz",
       "integrity": "sha1-B4g8rTcrFzowq8Wm1VpUAecI/tg=",
       "requires": {
         "@govflanders/vl-ui-core": "^3.7.2",
@@ -747,7 +748,7 @@
     },
     "@govflanders/vl-ui-toggle": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-toggle/vl-ui-toggle-3.7.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-toggle/vl-ui-toggle-3.7.3.tgz",
       "integrity": "sha1-Z/3nOYawjlummGlqhee5gy3rXGQ=",
       "requires": {
         "@govflanders/vl-ui-accordion": "^3.7.2",
@@ -761,7 +762,7 @@
     },
     "@govflanders/vl-ui-util": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-util/vl-ui-util-3.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-util/vl-ui-util-3.7.2.tgz",
       "integrity": "sha1-9+oj5SQVBBQrYrKd9JtIqsKJlg8=",
       "requires": {
         "@govflanders/vl-ui-core": "^3.7.2",
@@ -773,34 +774,34 @@
     },
     "@polymer/esm-amd-loader": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
       "integrity": "sha1-Tnfy9ZspsB4K0CqoPTNxbN3F+fk=",
       "dev": true
     },
     "@polymer/polymer": {
-      "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/polymer/-/polymer-3.2.0.tgz",
-      "integrity": "sha1-tB/d7E7KxjsSk2uTcmZ40jrdev0=",
+      "version": "3.3.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/polymer/-/polymer-3.3.0.tgz",
+      "integrity": "sha1-UqBmWsKWVHKOj0bo7heMAsSe/dA=",
       "dev": true,
       "requires": {
-        "@webcomponents/shadycss": "^1.8.0"
+        "@webcomponents/shadycss": "^1.9.1"
       }
     },
     "@polymer/sinonjs": {
       "version": "1.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
       "integrity": "sha1-5H03hbfQ6MKf65f36SSw/Fl+Lps=",
       "dev": true
     },
     "@polymer/test-fixture": {
       "version": "3.0.0-pre.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-3.0.0-pre.21.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-3.0.0-pre.21.tgz",
       "integrity": "sha1-hRUiB8sL9XyuvBkcgLsP22lSYU4=",
       "dev": true
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
       "integrity": "sha1-7N9I1TLFjqR3rPyrgDSEJPjQZi8=",
       "dev": true,
       "requires": {
@@ -809,7 +810,7 @@
     },
     "@types/babel-generator": {
       "version": "6.25.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-generator/-/babel-generator-6.25.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-generator/-/babel-generator-6.25.3.tgz",
       "integrity": "sha1-jwbKoS0FlaBThWCr53GWbXfSkoY=",
       "dev": true,
       "requires": {
@@ -818,7 +819,7 @@
     },
     "@types/babel-traverse": {
       "version": "6.25.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-traverse/-/babel-traverse-6.25.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-traverse/-/babel-traverse-6.25.5.tgz",
       "integrity": "sha1-bSk891I+SLUk+qe4bcPEiBkUhOU=",
       "dev": true,
       "requires": {
@@ -827,13 +828,13 @@
     },
     "@types/babel-types": {
       "version": "6.25.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-types/-/babel-types-6.25.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-types/-/babel-types-6.25.2.tgz",
       "integrity": "sha1-XFf0WXPk8TdC28UnPdhM/+c3Op4=",
       "dev": true
     },
     "@types/babylon": {
       "version": "6.16.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babylon/-/babylon-6.16.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babylon/-/babylon-6.16.5.tgz",
       "integrity": "sha1-HFZB22nrjN83jt0ltL53VL7rSLQ=",
       "dev": true,
       "requires": {
@@ -842,13 +843,13 @@
     },
     "@types/bluebird": {
       "version": "3.5.27",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/bluebird/-/bluebird-3.5.27.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/bluebird/-/bluebird-3.5.27.tgz",
       "integrity": "sha1-YetNddxr+85Rz0num76+lBsstdA=",
       "dev": true
     },
     "@types/body-parser": {
       "version": "1.17.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/body-parser/-/body-parser-1.17.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/body-parser/-/body-parser-1.17.0.tgz",
       "integrity": "sha1-n1ydm9BLtUvjLV65/A2Ml05s9Yw=",
       "dev": true,
       "requires": {
@@ -858,13 +859,13 @@
     },
     "@types/chai": {
       "version": "4.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chai/-/chai-4.1.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chai/-/chai-4.1.7.tgz",
       "integrity": "sha1-G44zthqMCcvh+FEzBxuqDb+fpxo=",
       "dev": true
     },
     "@types/chai-subset": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chai-subset/-/chai-subset-1.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chai-subset/-/chai-subset-1.3.2.tgz",
       "integrity": "sha1-FuMmfgVXquwNd2UcDOJ7aE9GAsE=",
       "dev": true,
       "requires": {
@@ -873,13 +874,13 @@
     },
     "@types/chalk": {
       "version": "0.4.31",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chalk/-/chalk-0.4.31.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chalk/-/chalk-0.4.31.tgz",
       "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk=",
       "dev": true
     },
     "@types/clean-css": {
       "version": "4.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/clean-css/-/clean-css-4.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha1-ywE0JB7F5u3htTRLyClmj9mHGo0=",
       "dev": true,
       "requires": {
@@ -888,13 +889,13 @@
     },
     "@types/clone": {
       "version": "0.1.30",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/clone/-/clone-0.1.30.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/clone/-/clone-0.1.30.tgz",
       "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
       "dev": true
     },
     "@types/compression": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/compression/-/compression-0.0.33.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/compression/-/compression-0.0.33.tgz",
       "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
       "dev": true,
       "requires": {
@@ -903,7 +904,7 @@
     },
     "@types/connect": {
       "version": "3.4.32",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/connect/-/connect-3.4.32.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/connect/-/connect-3.4.32.tgz",
       "integrity": "sha1-qg6WFrlDXMrQK8UrW0VP/Cxwuig=",
       "dev": true,
       "requires": {
@@ -912,43 +913,43 @@
     },
     "@types/content-type": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/content-type/-/content-type-1.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/content-type/-/content-type-1.1.3.tgz",
       "integrity": "sha1-Noi9d/wS+TVUju8QKk40xRKwOgc=",
       "dev": true
     },
     "@types/cssbeautify": {
       "version": "0.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8=",
       "dev": true
     },
     "@types/doctrine": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/doctrine/-/doctrine-0.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/doctrine/-/doctrine-0.0.1.tgz",
       "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0=",
       "dev": true
     },
     "@types/escape-html": {
       "version": "0.0.20",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/escape-html/-/escape-html-0.0.20.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/escape-html/-/escape-html-0.0.20.tgz",
       "integrity": "sha1-yuaYcU3WHr7lqz8q65o0uhARc1o=",
       "dev": true
     },
     "@types/estree": {
       "version": "0.0.39",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/estree/-/estree-0.0.39.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha1-4Xfmme4bjCLSMXTKqnQiZEOJUJ8=",
       "dev": true
     },
     "@types/events": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/events/-/events-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
       "dev": true
     },
     "@types/express": {
       "version": "4.17.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/express/-/express-4.17.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/express/-/express-4.17.0.tgz",
       "integrity": "sha1-SertsglYKobxLtm3JRYPEtBO8oc=",
       "dev": true,
       "requires": {
@@ -959,7 +960,7 @@
     },
     "@types/express-serve-static-core": {
       "version": "4.16.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
       "integrity": "sha1-ULpvimkcCKPdn6f7ol7zEz0pgEk=",
       "dev": true,
       "requires": {
@@ -969,14 +970,14 @@
     },
     "@types/freeport": {
       "version": "1.0.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/freeport/-/freeport-1.0.21.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/freeport/-/freeport-1.0.21.tgz",
       "integrity": "sha1-c/ZUPtZ9PKP/+XuYVZFZi3CSBm8=",
       "dev": true,
       "optional": true
     },
     "@types/glob": {
       "version": "7.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/glob/-/glob-7.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
       "dev": true,
       "requires": {
@@ -987,7 +988,7 @@
     },
     "@types/glob-stream": {
       "version": "6.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/glob-stream/-/glob-stream-6.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/glob-stream/-/glob-stream-6.1.0.tgz",
       "integrity": "sha1-ft6KM+WRQFNPjYrfuKye37MYl7w=",
       "dev": true,
       "requires": {
@@ -997,7 +998,7 @@
     },
     "@types/gulp-if": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/gulp-if/-/gulp-if-0.0.33.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/gulp-if/-/gulp-if-0.0.33.tgz",
       "integrity": "sha1-7eziK3kl2abbX5yMDXiCqndvtng=",
       "dev": true,
       "requires": {
@@ -1007,7 +1008,7 @@
     },
     "@types/html-minifier": {
       "version": "3.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/html-minifier/-/html-minifier-3.5.3.tgz",
       "integrity": "sha1-UnaEUTjbLOvFTHieCq+HYhoh6E8=",
       "dev": true,
       "requires": {
@@ -1018,32 +1019,32 @@
     },
     "@types/is-windows": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
       "dev": true
     },
     "@types/launchpad": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/launchpad/-/launchpad-0.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/launchpad/-/launchpad-0.6.0.tgz",
       "integrity": "sha1-NylhCbfyd/bmxf1+DAcGvJGPu1E=",
       "dev": true,
       "optional": true
     },
     "@types/mime": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mime/-/mime-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mime/-/mime-2.0.1.tgz",
       "integrity": "sha1-3EiIQjEqfwdRSTEpBbXjwLBUx50=",
       "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
       "dev": true
     },
     "@types/mz": {
       "version": "0.0.29",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.29.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.29.tgz",
       "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
       "dev": true,
       "requires": {
@@ -1052,14 +1053,14 @@
       }
     },
     "@types/node": {
-      "version": "12.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/node/-/node-12.0.8.tgz",
-      "integrity": "sha1-VRRmvhGyrcPz1HFWdY9hC9n2sdg=",
+      "version": "12.6.8",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/node/-/node-12.6.8.tgz",
+      "integrity": "sha1-5Gm0v50cmDKu5JB7qKBRSUNXwSw=",
       "dev": true
     },
     "@types/opn": {
       "version": "3.0.28",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/opn/-/opn-3.0.28.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/opn/-/opn-3.0.28.tgz",
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "dev": true,
       "requires": {
@@ -1068,7 +1069,7 @@
     },
     "@types/parse5": {
       "version": "2.2.34",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/parse5/-/parse5-2.2.34.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
@@ -1077,13 +1078,13 @@
     },
     "@types/path-is-inside": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
       "integrity": "sha1-Atb/OJddaEveyWIESUuvnynw4X8=",
       "dev": true
     },
     "@types/pem": {
       "version": "1.9.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/pem/-/pem-1.9.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/pem/-/pem-1.9.5.tgz",
       "integrity": "sha1-zVVIteCstLQaniEGfp/NjFcInJk=",
       "dev": true,
       "requires": {
@@ -1092,19 +1093,19 @@
     },
     "@types/range-parser": {
       "version": "1.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw=",
       "dev": true
     },
     "@types/relateurl": {
       "version": "0.2.28",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/relateurl/-/relateurl-0.2.28.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/relateurl/-/relateurl-0.2.28.tgz",
       "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y=",
       "dev": true
     },
     "@types/resolve": {
       "version": "0.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.6.tgz",
       "integrity": "sha1-C9LyNsLhzruYt5iF31ft1xqNdw4=",
       "dev": true,
       "requires": {
@@ -1113,7 +1114,7 @@
     },
     "@types/serve-static": {
       "version": "1.13.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/serve-static/-/serve-static-1.13.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha1-9axNemQgqZpqRa9HGfTc2M2Qekg=",
       "dev": true,
       "requires": {
@@ -1123,7 +1124,7 @@
     },
     "@types/spdy": {
       "version": "3.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/spdy/-/spdy-3.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/spdy/-/spdy-3.4.4.tgz",
       "integrity": "sha1-MoL9StjEYDqkn3AX3VIKCKNFsrw=",
       "dev": true,
       "requires": {
@@ -1132,13 +1133,13 @@
     },
     "@types/ua-parser-js": {
       "version": "0.7.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
       "integrity": "sha1-SpIIlRFXThKSiny2uZoBgxrNHdc=",
       "dev": true
     },
     "@types/uglify-js": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/uglify-js/-/uglify-js-3.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/uglify-js/-/uglify-js-3.0.4.tgz",
       "integrity": "sha1-lr6uI99vVhhiqDC0KIpJ6GuqwII=",
       "dev": true,
       "requires": {
@@ -1146,9 +1147,9 @@
       }
     },
     "@types/uuid": {
-      "version": "3.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/uuid/-/uuid-3.4.4.tgz",
-      "integrity": "sha1-evaTYPpl7w3stB/RUL9MpcDO/fU=",
+      "version": "3.4.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/uuid/-/uuid-3.4.5.tgz",
+      "integrity": "sha1-1NwQeFtJehR06uC6fwywnA3f1us=",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1156,7 +1157,7 @@
     },
     "@types/vinyl": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/vinyl/-/vinyl-2.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/vinyl/-/vinyl-2.0.3.tgz",
       "integrity": "sha1-gKbONiq1syoMmOhgdIoxvOm/8N4=",
       "dev": true,
       "requires": {
@@ -1165,7 +1166,7 @@
     },
     "@types/vinyl-fs": {
       "version": "2.4.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
       "integrity": "sha1-uYEZuLsklBQer2SbCfv+sxEWEgY=",
       "dev": true,
       "requires": {
@@ -1176,7 +1177,7 @@
     },
     "@types/whatwg-url": {
       "version": "6.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
       "integrity": "sha1-Hlm4xkvA299m0DfPhEnRw9UnAjc=",
       "dev": true,
       "requires": {
@@ -1185,31 +1186,31 @@
     },
     "@types/which": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/which/-/which-1.3.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/which/-/which-1.3.1.tgz",
       "integrity": "sha1-eALDgIh5hsqQkAiv6k4IAlsTD40=",
       "dev": true,
       "optional": true
     },
     "@webcomponents/shadycss": {
       "version": "1.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/shadycss/-/shadycss-1.9.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/shadycss/-/shadycss-1.9.1.tgz",
       "integrity": "sha1-12n7rfpQTxG4TK7vJnAfiQcOxJo=",
       "dev": true
     },
     "@webcomponents/webcomponentsjs": {
       "version": "2.2.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.10.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.10.tgz",
       "integrity": "sha1-b2vuAneDOumNfltG8eD9tIzV/0Q=",
       "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
     },
     "accepts": {
       "version": "1.3.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/accepts/-/accepts-1.3.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
       "dev": true,
       "requires": {
@@ -1219,19 +1220,19 @@
     },
     "accessibility-developer-tools": {
       "version": "2.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
       "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
       "dev": true
     },
     "acorn": {
       "version": "5.7.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-5.7.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-5.7.3.tgz",
       "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk=",
       "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -1240,7 +1241,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -1248,20 +1249,20 @@
     },
     "adm-zip": {
       "version": "0.4.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/adm-zip/-/adm-zip-0.4.13.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/adm-zip/-/adm-zip-0.4.13.tgz",
       "integrity": "sha1-WX4vjMNnIVHhMH0+lc3bx1ZyMUo=",
       "dev": true,
       "optional": true
     },
     "after": {
       "version": "0.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/after/-/after-0.8.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
     "agent-base": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/agent-base/-/agent-base-4.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/agent-base/-/agent-base-4.3.0.tgz",
       "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
       "dev": true,
       "optional": true,
@@ -1271,7 +1272,7 @@
       "dependencies": {
         "es6-promisify": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "dev": true,
           "optional": true,
@@ -1282,9 +1283,9 @@
       }
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
+      "version": "6.10.2",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1294,7 +1295,7 @@
     },
     "ansi-align": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
@@ -1303,19 +1304,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -1325,7 +1326,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -1334,118 +1335,170 @@
         }
       }
     },
+    "ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha1-Y3S03V1HGP884npnGjscrQdxMqk=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "^0.1.0"
+      }
+    },
     "ansi-escapes": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
       "dev": true
     },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
     },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
     "any-observable": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.3.0.tgz",
       "integrity": "sha1-r5M0deWAamfQ198JDdXovvZdEZs=",
       "dev": true
     },
     "any-promise": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-promise/-/any-promise-1.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
     },
     "append-field": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/append-field/-/append-field-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=",
       "dev": true
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aproba/-/aproba-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
     },
     "archiver": {
-      "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/archiver/-/archiver-2.1.1.tgz",
-      "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+      "version": "3.0.3",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/archiver/-/archiver-3.0.3.tgz",
+      "integrity": "sha1-dIe+UXJlBhnrXjpHMDKjSKNBLNw=",
       "dev": true,
       "requires": {
-        "archiver-utils": "^1.3.0",
-        "async": "^2.0.0",
+        "archiver-utils": "^2.1.0",
+        "async": "^2.6.3",
         "buffer-crc32": "^0.2.1",
-        "glob": "^7.0.0",
-        "lodash": "^4.8.0",
-        "readable-stream": "^2.0.0",
-        "tar-stream": "^1.5.0",
-        "zip-stream": "^1.2.0"
+        "glob": "^7.1.4",
+        "readable-stream": "^3.4.0",
+        "tar-stream": "^2.1.0",
+        "zip-stream": "^2.1.0"
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.2.tgz",
-          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
+          "version": "2.6.3",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
           }
         },
         "bl": {
-          "version": "1.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bl/-/bl-1.2.2.tgz",
-          "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
+          "version": "3.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bl/-/bl-3.0.0.tgz",
+          "integrity": "sha1-NhHsAFef0YVhdUNgsh6feEUA/4g=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
+            "readable-stream": "^3.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha1-pRwmdUZY4KPCHb9ZFjvUW6b0R/w=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha1-/obnOLGVRK/nBGkkOyoe6SQOro0=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         },
         "tar-stream": {
-          "version": "1.6.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-1.6.2.tgz",
-          "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
+          "version": "2.1.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.1.0.tgz",
+          "integrity": "sha1-0aqjZh8Fs4tazJtwIO/cpReaLMM=",
           "dev": true,
           "requires": {
-            "bl": "^1.0.0",
-            "buffer-alloc": "^1.2.0",
-            "end-of-stream": "^1.0.0",
+            "bl": "^3.0.0",
+            "end-of-stream": "^1.4.1",
             "fs-constants": "^1.0.0",
-            "readable-stream": "^2.3.0",
-            "to-buffer": "^1.1.1",
-            "xtend": "^4.0.0"
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
           }
         }
       }
     },
     "archiver-utils": {
-      "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/archiver-utils/-/archiver-utils-1.3.0.tgz",
-      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "version": "2.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha1-6KRg6UtpPD49oYKgmMpihbqSSeI=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "graceful-fs": "^4.1.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
         "lazystream": "^1.0.0",
-        "lodash": "^4.8.0",
-        "normalize-path": "^2.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
         "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+          "dev": true
+        }
       }
     },
     "are-we-there-yet": {
       "version": "1.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
       "requires": {
         "delegates": "^1.0.0",
@@ -1454,7 +1507,7 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -1462,43 +1515,43 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-back": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha1-uIWdelCIccmnss9C+ZQo9l6Wv7A=",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -1507,31 +1560,31 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
       "integrity": "sha1-O7xCdd1YTMGxCAm4nU6LY6aednU=",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -1539,57 +1592,57 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assertion-error/-/assertion-error-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-1.5.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-limiter": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async-limiter/-/async-limiter-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/atob/-/atob-2.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aws4/-/aws4-1.8.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
@@ -1600,13 +1653,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1619,13 +1672,13 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-3.0.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -1633,7 +1686,7 @@
     },
     "babel-generator": {
       "version": "6.26.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-generator/-/babel-generator-6.26.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
       "dev": true,
       "requires": {
@@ -1649,13 +1702,13 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -1663,64 +1716,73 @@
     },
     "babel-helper-evaluate-path": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
       "integrity": "sha1-pi+pxOZP9+pc6pNTF07wI6kApnw=",
       "dev": true
     },
     "babel-helper-flip-expressions": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
       "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0=",
       "dev": true
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
       "dev": true
     },
     "babel-helper-is-void-0": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
       "integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4=",
       "dev": true
     },
     "babel-helper-mark-eval-scopes": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
       "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI=",
       "dev": true
     },
     "babel-helper-remove-or-void": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
       "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=",
       "dev": true
     },
     "babel-helper-to-multiple-sequence-expressions": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
       "integrity": "sha1-o/kk41YYgtQvz0iQeqmPeXmkWI0=",
       "dev": true
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha1-8A9Qe9qjw+P/bn5emNkKesq5b38=",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "babel-plugin-minify-builtins": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
       "integrity": "sha1-MeuC7RoNDv3DExL5O25HQc6Cw2s=",
       "dev": true
     },
     "babel-plugin-minify-constant-folding": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
       "integrity": "sha1-+EvI2/alYeXjUP+VriFrCtVRW24=",
       "dev": true,
       "requires": {
@@ -1729,7 +1791,7 @@
     },
     "babel-plugin-minify-dead-code-elimination": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.0.tgz",
       "integrity": "sha1-0j71RFI4rQbord9cHPauyDW82oc=",
       "dev": true,
       "requires": {
@@ -1741,7 +1803,7 @@
     },
     "babel-plugin-minify-flip-comparisons": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
       "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
       "dev": true,
       "requires": {
@@ -1750,7 +1812,7 @@
     },
     "babel-plugin-minify-guarded-expressions": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.3.tgz",
       "integrity": "sha1-zHCbRFP9IbHzAod0RMifiEJ845c=",
       "dev": true,
       "requires": {
@@ -1759,13 +1821,13 @@
     },
     "babel-plugin-minify-infinity": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
       "integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco=",
       "dev": true
     },
     "babel-plugin-minify-mangle-names": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
       "integrity": "sha1-vN21B8kdLJnhOL1rF6GcPCceP9M=",
       "dev": true,
       "requires": {
@@ -1774,19 +1836,19 @@
     },
     "babel-plugin-minify-numeric-literals": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
       "integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw=",
       "dev": true
     },
     "babel-plugin-minify-replace": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
       "integrity": "sha1-0+LJlGyQlsBw78lnYc4ojsXD9xw=",
       "dev": true
     },
     "babel-plugin-minify-simplify": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.0.tgz",
       "integrity": "sha1-HwkAGK+5DYtU09An/YpJJ/JD2m8=",
       "dev": true,
       "requires": {
@@ -1797,7 +1859,7 @@
     },
     "babel-plugin-minify-type-constructors": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
       "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
       "dev": true,
       "requires": {
@@ -1806,31 +1868,31 @@
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
       "integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE=",
       "dev": true
     },
     "babel-plugin-transform-member-expression-literals": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
       "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=",
       "dev": true
     },
     "babel-plugin-transform-merge-sibling-variables": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
       "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=",
       "dev": true
     },
     "babel-plugin-transform-minify-booleans": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
       "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
       "dev": true
     },
     "babel-plugin-transform-property-literals": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
       "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
       "dev": true,
       "requires": {
@@ -1839,25 +1901,25 @@
     },
     "babel-plugin-transform-regexp-constructors": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
       "integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU=",
       "dev": true
     },
     "babel-plugin-transform-remove-console": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
       "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
       "dev": true
     },
     "babel-plugin-transform-remove-debugger": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
       "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI=",
       "dev": true
     },
     "babel-plugin-transform-remove-undefined": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
       "integrity": "sha1-gCCLMSJXZsYwyX+i0oiVIFbqIt0=",
       "dev": true,
       "requires": {
@@ -1866,19 +1928,19 @@
     },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
       "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
       "dev": true
     },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
       "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
       "dev": true
     },
     "babel-preset-minify": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-preset-minify/-/babel-preset-minify-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-preset-minify/-/babel-preset-minify-0.5.0.tgz",
       "integrity": "sha1-4lu401kAh68CtlCWcVmnfBm/uWs=",
       "dev": true,
       "requires": {
@@ -1909,7 +1971,7 @@
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
@@ -1919,7 +1981,7 @@
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
@@ -1936,13 +1998,13 @@
       "dependencies": {
         "babylon": {
           "version": "6.18.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babylon/-/babylon-6.18.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babylon/-/babylon-6.18.0.tgz",
           "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
           "dev": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -1951,13 +2013,13 @@
         },
         "globals": {
           "version": "9.18.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-9.18.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-9.18.0.tgz",
           "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -1965,7 +2027,7 @@
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
@@ -1977,7 +2039,7 @@
       "dependencies": {
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         }
@@ -1985,24 +2047,24 @@
     },
     "babylon": {
       "version": "7.0.0-beta.47",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babylon/-/babylon-7.0.0-beta.47.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babylon/-/babylon-7.0.0-beta.47.tgz",
       "integrity": "sha1-bR+kTwq+xBq3x4BIHmL9mq+96oA=",
       "dev": true
     },
     "backo2": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/backo2/-/backo2-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base/-/base-0.11.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
@@ -2017,7 +2079,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -2026,7 +2088,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -2035,7 +2097,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -2044,7 +2106,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -2057,25 +2119,25 @@
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
     },
     "base64-js": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64-js/-/base64-js-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64-js/-/base64-js-1.2.0.tgz",
       "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
       "dev": true
     },
     "base64id": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64id/-/base64id-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -2083,7 +2145,7 @@
     },
     "better-assert": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/better-assert/-/better-assert-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "dev": true,
       "requires": {
@@ -2092,7 +2154,7 @@
     },
     "bindings": {
       "version": "1.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bindings/-/bindings-1.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
       "requires": {
         "file-uri-to-path": "1.0.0"
@@ -2100,7 +2162,7 @@
     },
     "bl": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bl/-/bl-2.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bl/-/bl-2.2.0.tgz",
       "integrity": "sha1-4aV0zfUo5AUwGbuACwQcCsiNpJM=",
       "dev": true,
       "optional": true,
@@ -2111,13 +2173,13 @@
     },
     "blob": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/blob/-/blob-0.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/blob/-/blob-0.0.5.tgz",
       "integrity": "sha1-1oDu7yX4zZGtUz9bAe7UjmTK9oM=",
       "dev": true
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
         "inherits": "~2.0.0"
@@ -2125,7 +2187,7 @@
     },
     "body-parser": {
       "version": "1.19.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/body-parser/-/body-parser-1.19.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "dev": true,
       "requires": {
@@ -2143,7 +2205,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -2152,13 +2214,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
           "dev": true
         }
@@ -2166,7 +2228,7 @@
     },
     "bower-config": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bower-config/-/bower-config-1.4.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bower-config/-/bower-config-1.4.1.tgz",
       "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
       "dev": true,
       "requires": {
@@ -2179,7 +2241,7 @@
     },
     "boxen": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
       "dev": true,
       "requires": {
@@ -2194,19 +2256,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -2216,7 +2278,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -2227,7 +2289,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "^1.0.0",
@@ -2236,7 +2298,7 @@
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-2.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-2.3.2.tgz",
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "dev": true,
       "requires": {
@@ -2254,7 +2316,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -2265,7 +2327,7 @@
     },
     "browser-capabilities": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-capabilities/-/browser-capabilities-1.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-capabilities/-/browser-capabilities-1.1.4.tgz",
       "integrity": "sha1-pr1legehNFMq1mxyK4lJkER4uXM=",
       "dev": true,
       "requires": {
@@ -2275,13 +2337,13 @@
     },
     "browser-stdout": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
     "browserstack": {
       "version": "1.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browserstack/-/browserstack-1.5.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browserstack/-/browserstack-1.5.2.tgz",
       "integrity": "sha1-F9i7dhJ6HMDqQWQk34DSGPgDZz8=",
       "dev": true,
       "optional": true,
@@ -2291,7 +2353,7 @@
     },
     "buffer": {
       "version": "5.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer/-/buffer-5.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer/-/buffer-5.2.1.tgz",
       "integrity": "sha1-3Vf6DxCaxZxgJHkETcp7iz0LcdY=",
       "dev": true,
       "requires": {
@@ -2299,43 +2361,21 @@
         "ieee754": "^1.1.4"
       }
     },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
-      "dev": true,
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
-      "dev": true
-    },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "bufferstreams": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bufferstreams/-/bufferstreams-1.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bufferstreams/-/bufferstreams-1.1.3.tgz",
       "integrity": "sha1-qFFawCT6kOj6fVjBGxPeofKKvnI=",
       "requires": {
         "readable-stream": "^2.0.2"
@@ -2343,7 +2383,7 @@
     },
     "busboy": {
       "version": "0.2.14",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/busboy/-/busboy-0.2.14.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/busboy/-/busboy-0.2.14.tgz",
       "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
       "dev": true,
       "requires": {
@@ -2353,7 +2393,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -2367,13 +2407,13 @@
     },
     "bytes": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bytes/-/bytes-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
       "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
@@ -2390,13 +2430,13 @@
     },
     "callsite": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/callsite/-/callsite-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
@@ -2406,13 +2446,13 @@
     },
     "camelcase": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true
     },
     "camelcase-keys": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
@@ -2423,7 +2463,7 @@
     },
     "cancel-token": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cancel-token/-/cancel-token-0.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cancel-token/-/cancel-token-0.1.1.tgz",
       "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
       "dev": true,
       "requires": {
@@ -2432,7 +2472,7 @@
       "dependencies": {
         "@types/node": {
           "version": "4.9.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/node/-/node-4.9.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/node/-/node-4.9.3.tgz",
           "integrity": "sha1-okaXqBV6tReZav4MiPpxZVCuQZo=",
           "dev": true
         }
@@ -2440,18 +2480,18 @@
     },
     "capture-stack-trace": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10=",
       "dev": true
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "3.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai/-/chai-3.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
@@ -2462,7 +2502,7 @@
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "requires": {
@@ -2473,25 +2513,25 @@
     },
     "chardet": {
       "version": "0.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chardet/-/chardet-0.4.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
     "charenc": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/charenc/-/charenc-0.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
       "dev": true
     },
     "ci-info": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
       "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
@@ -2503,7 +2543,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -2514,12 +2554,12 @@
     },
     "classlist-polyfill": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
       "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4="
     },
     "clean-css": {
       "version": "4.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clean-css/-/clean-css-4.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha1-LUEe92uFabbQyEBo2r6FsKpeXBc=",
       "dev": true,
       "requires": {
@@ -2528,19 +2568,19 @@
     },
     "cleankill": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cleankill/-/cleankill-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cleankill/-/cleankill-2.0.0.tgz",
       "integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE=",
       "dev": true
     },
     "cli-boxes": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
@@ -2549,7 +2589,7 @@
     },
     "cli-truncate": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
       "dev": true,
       "requires": {
@@ -2559,7 +2599,7 @@
     },
     "cli-width": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-width/-/cli-width-2.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
@@ -2577,7 +2617,7 @@
     },
     "cliui": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-4.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-4.1.0.tgz",
       "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
       "dev": true,
       "requires": {
@@ -2588,19 +2628,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -2610,7 +2650,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -2621,24 +2661,24 @@
     },
     "clone": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone/-/clone-2.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
     "clone-stats": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone-stats/-/clone-stats-0.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -2648,7 +2688,7 @@
     },
     "color": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color/-/color-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color/-/color-3.0.0.tgz",
       "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
       "dev": true,
       "requires": {
@@ -2658,7 +2698,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-1.9.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
@@ -2667,13 +2707,13 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "color-string": {
       "version": "1.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-string/-/color-string-1.5.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=",
       "dev": true,
       "requires": {
@@ -2681,20 +2721,26 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
+      "dev": true
+    },
     "colornames": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colornames/-/colornames-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colornames/-/colornames-1.1.1.tgz",
       "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
       "dev": true
     },
     "colors": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colors/-/colors-1.3.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colors/-/colors-1.3.3.tgz",
       "integrity": "sha1-OeAF1Uav4B4B+cTKj6UPaGoBIF0="
     },
     "colorspace": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colorspace/-/colorspace-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colorspace/-/colorspace-1.1.2.tgz",
       "integrity": "sha1-4BKJUNCCuGohaFgHlqCqXWxo2MU=",
       "dev": true,
       "requires": {
@@ -2704,7 +2750,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -2712,7 +2758,7 @@
     },
     "command-line-args": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/command-line-args/-/command-line-args-5.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/command-line-args/-/command-line-args-5.1.1.tgz",
       "integrity": "sha1-iOeT5bs86zB1SoaGPwQBrJL9Npo=",
       "dev": true,
       "requires": {
@@ -2724,7 +2770,7 @@
     },
     "command-line-usage": {
       "version": "5.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/command-line-usage/-/command-line-usage-5.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/command-line-usage/-/command-line-usage-5.0.5.tgz",
       "integrity": "sha1-XyWTP/5t7dmDxjXTiiHX5iP9o1c=",
       "dev": true,
       "requires": {
@@ -2736,7 +2782,7 @@
       "dependencies": {
         "array-back": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
           "dev": true,
           "requires": {
@@ -2745,7 +2791,7 @@
         },
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
@@ -2753,42 +2799,50 @@
     },
     "commander": {
       "version": "2.20.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.20.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.20.0.tgz",
       "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI="
     },
     "component-bind": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-bind/-/component-bind-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-bind/-/component-bind-1.0.0.tgz",
       "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
       "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
       "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-inherit/-/component-inherit-0.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "compress-commons": {
-      "version": "1.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compress-commons/-/compress-commons-1.2.2.tgz",
-      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "version": "2.0.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compress-commons/-/compress-commons-2.0.0.tgz",
+      "integrity": "sha1-xVUQfvhl7vC6ijH+Vux5+BPtPmU=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "^0.2.1",
+        "buffer-crc32": "^0.2.13",
         "crc32-stream": "^2.0.0",
-        "normalize-path": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.3.6"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+          "dev": true
+        }
       }
     },
     "compressible": {
       "version": "2.0.17",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compressible/-/compressible-2.0.17.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compressible/-/compressible-2.0.17.tgz",
       "integrity": "sha1-bowQihatWDhKl386SCyiC/8vOME=",
       "dev": true,
       "requires": {
@@ -2797,7 +2851,7 @@
     },
     "compression": {
       "version": "1.7.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compression/-/compression-1.7.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compression/-/compression-1.7.4.tgz",
       "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
       "dev": true,
       "requires": {
@@ -2812,13 +2866,13 @@
       "dependencies": {
         "bytes": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bytes/-/bytes-3.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bytes/-/bytes-3.0.0.tgz",
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
           "dev": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -2827,7 +2881,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -2835,12 +2889,12 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
@@ -2852,7 +2906,7 @@
     },
     "configstore": {
       "version": "3.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
       "dev": true,
       "requires": {
@@ -2866,12 +2920,12 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-disposition": {
       "version": "0.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/content-disposition/-/content-disposition-0.5.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
       "dev": true,
       "requires": {
@@ -2880,13 +2934,13 @@
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
       "dev": true,
       "requires": {
@@ -2895,25 +2949,25 @@
     },
     "cookie": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie/-/cookie-0.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo=",
       "dev": true
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
     "copyfiles": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/copyfiles/-/copyfiles-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/copyfiles/-/copyfiles-2.1.0.tgz",
       "integrity": "sha1-DipBiBYtay88Wt/jTpwL1WTSMWQ=",
       "dev": true,
       "requires": {
@@ -2927,18 +2981,18 @@
     },
     "core-js": {
       "version": "2.6.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-js/-/core-js-2.6.9.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-js/-/core-js-2.6.9.tgz",
       "integrity": "sha1-a0shRiDINBUuF5Mjcn/Bl0GwhPI=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.8.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cors/-/cors-2.8.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cors/-/cors-2.8.5.tgz",
       "integrity": "sha1-6sEdpRWS3Ya58G9uesKTs9+HXSk=",
       "dev": true,
       "requires": {
@@ -2948,13 +3002,13 @@
     },
     "corser": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/corser/-/corser-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/corser/-/corser-2.0.1.tgz",
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
       "dev": true
     },
     "crc": {
       "version": "3.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crc/-/crc-3.8.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crc/-/crc-3.8.0.tgz",
       "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
       "dev": true,
       "requires": {
@@ -2963,7 +3017,7 @@
     },
     "crc32-stream": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crc32-stream/-/crc32-stream-2.0.0.tgz",
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
@@ -2973,7 +3027,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
@@ -2982,7 +3036,7 @@
     },
     "cross-spawn": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
@@ -2993,19 +3047,19 @@
     },
     "crypt": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypt/-/crypt-0.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
       "dev": true
     },
     "crypto-random-string": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
     "css-slam": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-slam/-/css-slam-2.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-slam/-/css-slam-2.1.2.tgz",
       "integrity": "sha1-PTWxkiyz4AAqRciasYlJJQjEk+U=",
       "dev": true,
       "requires": {
@@ -3018,32 +3072,38 @@
     },
     "css-vars-ponyfill": {
       "version": "1.17.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-vars-ponyfill/-/css-vars-ponyfill-1.17.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-vars-ponyfill/-/css-vars-ponyfill-1.17.2.tgz",
       "integrity": "sha1-GOx7wv0Ybr+vme42eyYortQ4ids="
     },
     "cssbeautify": {
       "version": "0.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c=",
       "dev": true
     },
     "cubic2quad": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cubic2quad/-/cubic2quad-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cubic2quad/-/cubic2quad-1.1.1.tgz",
       "integrity": "sha1-abGcYaP1tB7PLx1fro+wNBWqixU="
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
         "array-find-index": "^1.0.1"
       }
     },
+    "dargs": {
+      "version": "5.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dargs/-/dargs-5.1.0.tgz",
+      "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk=",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -3051,13 +3111,13 @@
     },
     "date-fns": {
       "version": "1.30.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/date-fns/-/date-fns-1.30.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha1-LnG/CxGRU9u0zE6I2epaz7UNwFw=",
       "dev": true
     },
     "debug": {
       "version": "3.2.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
       "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
       "dev": true,
       "requires": {
@@ -3066,13 +3126,13 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
@@ -3082,7 +3142,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         }
@@ -3090,13 +3150,13 @@
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "deep-eql": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-0.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
       "requires": {
@@ -3105,7 +3165,7 @@
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-0.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-0.1.1.tgz",
           "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
           "dev": true
         }
@@ -3113,13 +3173,13 @@
     },
     "deep-extend": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-extend/-/deep-extend-0.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
       "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
@@ -3128,7 +3188,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
@@ -3138,7 +3198,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -3147,7 +3207,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -3156,7 +3216,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -3169,7 +3229,7 @@
     },
     "del": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/del/-/del-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
@@ -3183,7 +3243,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegate": {
@@ -3195,30 +3255,30 @@
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delegates/-/delegates-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-file/-/detect-file-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "detect-indent": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-indent/-/detect-indent-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
@@ -3227,13 +3287,13 @@
     },
     "detect-node": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-node/-/detect-node-2.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw=",
       "dev": true
     },
     "diagnostics": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diagnostics/-/diagnostics-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diagnostics/-/diagnostics-1.1.1.tgz",
       "integrity": "sha1-yrasM99wydmnJ0kK5DrJladpsio=",
       "dev": true,
       "requires": {
@@ -3244,7 +3304,7 @@
     },
     "dicer": {
       "version": "0.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dicer/-/dicer-0.2.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "dev": true,
       "requires": {
@@ -3254,7 +3314,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3268,13 +3328,13 @@
     },
     "diff": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-3.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/doctrine/-/doctrine-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
       "dev": true,
       "requires": {
@@ -3283,7 +3343,7 @@
     },
     "document-register-element": {
       "version": "1.13.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/document-register-element/-/document-register-element-1.13.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/document-register-element/-/document-register-element-1.13.2.tgz",
       "integrity": "sha1-4Xc5Qfbjk0Wu/skJzHU+gpk7QV0=",
       "requires": {
         "lightercollective": "^0.3.0"
@@ -3291,7 +3351,7 @@
     },
     "dom-urls": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom-urls/-/dom-urls-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "dev": true,
       "requires": {
@@ -3300,7 +3360,7 @@
     },
     "dom5": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom5/-/dom5-3.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom5/-/dom5-3.0.1.tgz",
       "integrity": "sha1-zfxzMfN24oS/N55uoFSvwTZwKUQ=",
       "dev": true,
       "requires": {
@@ -3311,7 +3371,7 @@
     },
     "dot-prop": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
       "dev": true,
       "requires": {
@@ -3320,7 +3380,7 @@
     },
     "duplexer2": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
@@ -3329,13 +3389,13 @@
     },
     "duplexer3": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer3/-/duplexer3-0.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexify/-/duplexify-3.7.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "dev": true,
       "requires": {
@@ -3347,7 +3407,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -3356,7 +3416,7 @@
     },
     "ecstatic": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ecstatic/-/ecstatic-3.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ecstatic/-/ecstatic-3.3.2.tgz",
       "integrity": "sha1-bR3UmBTQBZRoLGUq22YHamnUbEg=",
       "dev": true,
       "requires": {
@@ -3368,7 +3428,7 @@
       "dependencies": {
         "url-join": {
           "version": "2.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-join/-/url-join-2.0.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-join/-/url-join-2.0.5.tgz",
           "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
           "dev": true
         }
@@ -3376,25 +3436,25 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "emitter-component": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emitter-component/-/emitter-component-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emitter-component/-/emitter-component-1.1.1.tgz",
       "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=",
       "dev": true
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
@@ -3403,13 +3463,13 @@
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
@@ -3418,7 +3478,7 @@
     },
     "engine.io": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io/-/engine.io-3.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io/-/engine.io-3.3.2.tgz",
       "integrity": "sha1-GMvItvNulGHFwPgd8rgw3hYFilk=",
       "dev": true,
       "requires": {
@@ -3432,13 +3492,13 @@
       "dependencies": {
         "cookie": {
           "version": "0.3.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie/-/cookie-0.3.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
           "dev": true
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
           "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
@@ -3447,7 +3507,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -3455,7 +3515,7 @@
     },
     "engine.io-client": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io-client/-/engine.io-client-3.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io-client/-/engine.io-client-3.3.2.tgz",
       "integrity": "sha1-BOBoeY11vtoUN1omS7PXQte8M6o=",
       "dev": true,
       "requires": {
@@ -3474,13 +3534,13 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
           "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
@@ -3489,7 +3549,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -3497,7 +3557,7 @@
     },
     "engine.io-parser": {
       "version": "2.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
       "integrity": "sha1-dXq5cPvy37Mse3SwMyFtVznveaY=",
       "dev": true,
       "requires": {
@@ -3510,13 +3570,13 @@
     },
     "env-variable": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/env-variable/-/env-variable-0.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/env-variable/-/env-variable-0.0.5.tgz",
       "integrity": "sha1-kT3YML7xHpagOcA41BMGBOujf4g=",
       "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
@@ -3525,7 +3585,7 @@
     },
     "es-abstract": {
       "version": "1.13.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.13.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
       "dev": true,
       "requires": {
@@ -3539,7 +3599,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
       "dev": true,
       "requires": {
@@ -3550,31 +3610,31 @@
     },
     "es6-promise": {
       "version": "4.2.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promise/-/es6-promise-4.2.8.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo=",
       "dev": true
     },
     "es6-promisify": {
       "version": "6.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-6.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-6.0.1.tgz",
       "integrity": "sha1-btqkXzvVcP/gj+vOZvcRa+SxzbY=",
       "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/espree/-/espree-3.5.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/espree/-/espree-3.5.4.tgz",
       "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
       "dev": true,
       "requires": {
@@ -3589,26 +3649,26 @@
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/etag/-/etag-1.8.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eventemitter3": {
       "version": "3.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha1-LT1I+cNGaY/Og6hdfWZOmFNd9uc=",
       "dev": true
     },
     "execa": {
       "version": "0.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
@@ -3623,7 +3683,7 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
@@ -3638,7 +3698,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -3647,7 +3707,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -3656,7 +3716,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -3665,7 +3725,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -3673,7 +3733,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -3682,7 +3742,7 @@
       "dependencies": {
         "fill-range": {
           "version": "2.2.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-2.2.4.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-2.2.4.tgz",
           "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "dev": true,
           "requires": {
@@ -3695,7 +3755,7 @@
         },
         "is-number": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-2.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
@@ -3704,13 +3764,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true,
           "requires": {
@@ -3719,7 +3779,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -3730,7 +3790,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
@@ -3739,7 +3799,7 @@
     },
     "express": {
       "version": "4.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/express/-/express-4.17.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/express/-/express-4.17.1.tgz",
       "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
       "dev": true,
       "requires": {
@@ -3777,7 +3837,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -3786,19 +3846,19 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
           "dev": true
         },
         "send": {
           "version": "0.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
           "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
           "dev": true,
           "requires": {
@@ -3819,7 +3879,7 @@
           "dependencies": {
             "ms": {
               "version": "2.1.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
+              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
               "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
               "dev": true
             }
@@ -3829,12 +3889,12 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend/-/extend-3.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -3844,7 +3904,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -3855,7 +3915,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
       "dev": true,
       "requires": {
@@ -3866,7 +3926,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "requires": {
@@ -3882,7 +3942,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -3891,7 +3951,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -3900,7 +3960,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -3909,7 +3969,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -3918,7 +3978,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -3931,28 +3991,40 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fancy-log": {
+      "version": "1.3.3",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fancy-log/-/fancy-log-1.3.3.tgz",
+      "integrity": "sha1-28GRVPVYaQFQojlToK29A1vkX8c=",
+      "dev": true,
+      "requires": {
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "parse-node-version": "^1.0.0",
+        "time-stamp": "^1.0.0"
+      }
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-safe-stringify": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
       "integrity": "sha1-BLJhBsxWaB9RoETPwNds8ACKwsI=",
       "dev": true
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "optional": true,
@@ -3962,13 +4034,13 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha1-lI50FX3xoy/RsSw6PDzctuydls0=",
       "dev": true
     },
     "figures": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
@@ -3977,18 +4049,18 @@
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90="
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/filename-regex/-/filename-regex-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
@@ -4000,7 +4072,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -4011,7 +4083,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
       "dev": true,
       "requires": {
@@ -4026,7 +4098,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -4035,7 +4107,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -4043,7 +4115,7 @@
     },
     "find-port": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-port/-/find-port-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-port/-/find-port-1.0.1.tgz",
       "integrity": "sha1-2whKbL+ZVk2Zhprnn73s9m6KGFw=",
       "dev": true,
       "requires": {
@@ -4052,7 +4124,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-0.2.10.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
           "dev": true
         }
@@ -4060,7 +4132,7 @@
     },
     "find-replace": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-replace/-/find-replace-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha1-Pn4j07BRZ6dvdwyfvVJYsN72jDg=",
       "dev": true,
       "requires": {
@@ -4069,7 +4141,7 @@
     },
     "find-up": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
@@ -4078,7 +4150,7 @@
     },
     "findup-sync": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/findup-sync/-/findup-sync-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/findup-sync/-/findup-sync-2.0.0.tgz",
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
@@ -4090,13 +4162,13 @@
     },
     "first-chunk-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
       "dev": true
     },
     "follow-redirects": {
       "version": "1.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/follow-redirects/-/follow-redirects-1.7.0.tgz",
       "integrity": "sha1-SJ68GY3A5/ZBZ70jsDxMGbV4THY=",
       "dev": true,
       "requires": {
@@ -4105,13 +4177,13 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/for-own/-/for-own-0.1.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
@@ -4120,18 +4192,18 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "fork-stream": {
       "version": "0.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fork-stream/-/fork-stream-0.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fork-stream/-/fork-stream-0.0.4.tgz",
       "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=",
       "dev": true
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "requires": {
         "asynckit": "^0.4.0",
@@ -4141,7 +4213,7 @@
     },
     "formatio": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/formatio/-/formatio-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
@@ -4150,13 +4222,13 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -4165,31 +4237,31 @@
     },
     "freeport": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/freeport/-/freeport-1.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/freeport/-/freeport-1.0.5.tgz",
       "integrity": "sha1-JV6KuEFwwzuoXZkOghrl9KGpvF0=",
       "dev": true,
       "optional": true
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs-constants": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs-constants/-/fs-constants-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fstream": {
       "version": "1.0.12",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fstream/-/fstream-1.0.12.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -4200,13 +4272,13 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gauge/-/gauge-2.7.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
         "aproba": "^1.0.3",
@@ -4221,31 +4293,31 @@
     },
     "get-caller-file": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
       "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -4253,13 +4325,13 @@
     },
     "github-url-from-git": {
       "version": "1.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
       "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
       "dev": true
     },
     "glob": {
       "version": "7.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.4.tgz",
       "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -4272,7 +4344,7 @@
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-base/-/glob-base-0.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
@@ -4282,13 +4354,13 @@
       "dependencies": {
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
@@ -4299,7 +4371,7 @@
     },
     "glob-parent": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
@@ -4308,13 +4380,13 @@
       "dependencies": {
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
@@ -4325,7 +4397,7 @@
     },
     "glob-stream": {
       "version": "5.3.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-stream/-/glob-stream-5.3.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-stream/-/glob-stream-5.3.5.tgz",
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "dev": true,
       "requires": {
@@ -4341,7 +4413,7 @@
       "dependencies": {
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
@@ -4350,13 +4422,13 @@
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
@@ -4367,7 +4439,7 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
@@ -4376,7 +4448,7 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
@@ -4385,7 +4457,7 @@
         },
         "glob": {
           "version": "5.0.15",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-5.0.15.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
@@ -4398,7 +4470,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -4408,13 +4480,13 @@
         },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4423,7 +4495,7 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
@@ -4444,7 +4516,7 @@
           "dependencies": {
             "is-glob": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
@@ -4455,7 +4527,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -4467,7 +4539,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-0.6.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
@@ -4479,7 +4551,7 @@
     },
     "global-dirs": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
@@ -4488,7 +4560,7 @@
     },
     "global-modules": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-modules/-/global-modules-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
       "dev": true,
       "requires": {
@@ -4499,7 +4571,7 @@
     },
     "global-prefix": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-prefix/-/global-prefix-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
@@ -4512,13 +4584,13 @@
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
       "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -4531,7 +4603,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -4549,7 +4621,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -4567,25 +4639,25 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA="
+      "version": "4.2.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "integrity": "sha1-jY/cc5d8sEEEchy1NmbBymTNMos="
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "growl": {
       "version": "1.9.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/growl/-/growl-1.9.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
     "gulp-if": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-if/-/gulp-if-2.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-if/-/gulp-if-2.0.2.tgz",
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "dev": true,
       "requires": {
@@ -4595,17 +4667,157 @@
       }
     },
     "gulp-match": {
-      "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-match/-/gulp-match-1.0.3.tgz",
-      "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
+      "version": "1.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-match/-/gulp-match-1.1.0.tgz",
+      "integrity": "sha1-VStwgPwAbudSyQVj+f7J1hqv308=",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.3"
       }
     },
+    "gulp-mocha": {
+      "version": "6.0.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-mocha/-/gulp-mocha-6.0.0.tgz",
+      "integrity": "sha1-gPMrxwXOMHR/NV3bjM2Wocc77xM=",
+      "dev": true,
+      "requires": {
+        "dargs": "^5.1.0",
+        "execa": "^0.10.0",
+        "mocha": "^5.2.0",
+        "npm-run-path": "^2.0.2",
+        "plugin-error": "^1.0.1",
+        "supports-color": "^5.4.0",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.1",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
+          "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+          "dev": true
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha1-/0Vqj1P5D47MxxqW0Rvfx/CCy1A=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "growl": {
+          "version": "1.10.5",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/growl/-/growl-1.10.5.tgz",
+          "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+          "dev": true
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+          "dev": true
+        },
+        "mocha": {
+          "version": "5.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mocha/-/mocha-5.2.0.tgz",
+          "integrity": "sha1-bYrlCPWRZ/lA8rWzxKYSrlDJCuY=",
+          "dev": true,
+          "requires": {
+            "browser-stdout": "1.3.1",
+            "commander": "2.15.1",
+            "debug": "3.1.0",
+            "diff": "3.5.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.5",
+            "he": "1.1.1",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "supports-color": "5.4.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.4.0",
+              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.4.0.tgz",
+              "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=",
+          "dev": true
+        }
+      }
+    },
     "gulp-sourcemaps": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
@@ -4618,7 +4830,7 @@
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
@@ -4629,13 +4841,13 @@
     },
     "handle-thing": {
       "version": "1.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/handle-thing/-/handle-thing-1.2.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
       "dev": true
     },
     "handlebars": {
       "version": "4.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/handlebars/-/handlebars-4.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/handlebars/-/handlebars-4.1.2.tgz",
       "integrity": "sha1-trN8HO0DBrIh4JT8eso+wjsTG2c=",
       "requires": {
         "neo-async": "^2.6.0",
@@ -4646,12 +4858,12 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/har-validator/-/har-validator-5.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "requires": {
         "ajv": "^6.5.5",
@@ -4660,7 +4872,7 @@
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has/-/has-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
@@ -4669,7 +4881,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -4678,7 +4890,7 @@
     },
     "has-binary2": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-binary2/-/has-binary2-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-binary2/-/has-binary2-1.0.3.tgz",
       "integrity": "sha1-d3asYn8+p3JQz8My2rfd9eT10R0=",
       "dev": true,
       "requires": {
@@ -4687,7 +4899,7 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         }
@@ -4695,36 +4907,36 @@
     },
     "has-color": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-color/-/has-color-0.1.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-color/-/has-color-0.1.7.tgz",
       "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
       "dev": true
     },
     "has-cors": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-cors/-/has-cors-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-symbols/-/has-symbols-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -4735,7 +4947,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -4745,7 +4957,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -4756,19 +4968,19 @@
     },
     "has-yarn": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-yarn/-/has-yarn-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-yarn/-/has-yarn-1.0.0.tgz",
       "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
       "dev": true
     },
     "he": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.2.0.tgz",
       "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
       "dev": true,
       "requires": {
@@ -4777,13 +4989,13 @@
     },
     "hosted-git-info": {
       "version": "2.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
       "dev": true
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hpack.js/-/hpack.js-2.1.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
@@ -4795,7 +5007,7 @@
     },
     "html-minifier": {
       "version": "3.5.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/html-minifier/-/html-minifier-3.5.21.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/html-minifier/-/html-minifier-3.5.21.tgz",
       "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
       "dev": true,
       "requires": {
@@ -4810,13 +5022,13 @@
       "dependencies": {
         "commander": {
           "version": "2.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.17.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.17.1.tgz",
           "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
           "dev": true
         },
         "uglify-js": {
           "version": "3.4.10",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.4.10.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.4.10.tgz",
           "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
           "dev": true,
           "requires": {
@@ -4826,7 +5038,7 @@
           "dependencies": {
             "commander": {
               "version": "2.19.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.19.0.tgz",
+              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.19.0.tgz",
               "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=",
               "dev": true
             }
@@ -4836,13 +5048,13 @@
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
     "http-errors": {
       "version": "1.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
       "dev": true,
       "requires": {
@@ -4851,11 +5063,19 @@
         "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
       }
     },
     "http-proxy": {
       "version": "1.17.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-proxy/-/http-proxy-1.17.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha1-etOElGWPhGBeL220Q230EPTlvpo=",
       "dev": true,
       "requires": {
@@ -4866,7 +5086,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.17.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "dev": true,
       "requires": {
@@ -4878,7 +5098,7 @@
       "dependencies": {
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
@@ -4887,13 +5107,13 @@
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
@@ -4904,7 +5124,7 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
@@ -4913,7 +5133,7 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
@@ -4922,13 +5142,13 @@
         },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4937,7 +5157,7 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
@@ -4958,7 +5178,7 @@
           "dependencies": {
             "is-glob": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
@@ -4971,7 +5191,7 @@
     },
     "http-server": {
       "version": "0.11.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-server/-/http-server-0.11.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-server/-/http-server-0.11.1.tgz",
       "integrity": "sha1-IwKlam/+9/mr6gFH2Dil6ba2p5s=",
       "dev": true,
       "requires": {
@@ -4987,7 +5207,7 @@
       "dependencies": {
         "colors": {
           "version": "1.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colors/-/colors-1.0.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
           "dev": true
         }
@@ -4995,7 +5215,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -5004,19 +5224,19 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
+      "version": "2.2.2",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+      "integrity": "sha1-Jx6o6Q+DasnxGdrM05wZ/337B5M=",
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       }
     },
     "icon-font-generator": {
       "version": "2.1.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/icon-font-generator/-/icon-font-generator-2.1.10.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/icon-font-generator/-/icon-font-generator-2.1.10.tgz",
       "integrity": "sha1-ldbX88RNxopfvDey4alRFIc4fro=",
       "requires": {
         "colors": "^1.2.1",
@@ -5027,7 +5247,7 @@
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "dev": true,
       "requires": {
@@ -5036,43 +5256,43 @@
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ieee754/-/ieee754-1.1.13.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
       "dev": true
     },
     "import-lazy": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-lazy/-/import-lazy-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent/-/indent-0.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent/-/indent-0.0.2.tgz",
       "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk=",
       "dev": true
     },
     "indent-string": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-3.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -5080,19 +5300,19 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ini/-/ini-1.3.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ini/-/ini-1.3.5.tgz",
       "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
       "dev": true
     },
     "inquirer": {
       "version": "5.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-5.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-5.2.0.tgz",
       "integrity": "sha1-2zUMK3Paynf/EkOWLp8i8JloVyY=",
       "dev": true,
       "requires": {
@@ -5113,19 +5333,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "rxjs": {
           "version": "5.5.12",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rxjs/-/rxjs-5.5.12.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rxjs/-/rxjs-5.5.12.tgz",
           "integrity": "sha1-b6YbinfD15PbrycL7i9D9lLXQcw=",
           "dev": true,
           "requires": {
@@ -5134,7 +5354,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -5144,7 +5364,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -5155,12 +5375,12 @@
     },
     "intersection-observer": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/intersection-observer/-/intersection-observer-0.5.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/intersection-observer/-/intersection-observer-0.5.1.tgz",
       "integrity": "sha1-40D8Vs50KQ/isjlNHOiMQ1Osbfo="
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/invariant/-/invariant-2.2.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "dev": true,
       "requires": {
@@ -5169,19 +5389,19 @@
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/invert-kv/-/invert-kv-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "ipaddr.js": {
       "version": "1.9.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha1-N9905DCg5HVQ/lSi3v4w2KzZX2U=",
       "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -5190,7 +5410,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -5201,31 +5421,31 @@
     },
     "is-arguments": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arguments/-/is-arguments-1.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arguments/-/is-arguments-1.0.4.tgz",
       "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-callable/-/is-callable-1.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
       "dev": true
     },
     "is-ci": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
       "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
       "dev": true,
       "requires": {
@@ -5234,7 +5454,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -5243,7 +5463,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -5254,13 +5474,13 @@
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
@@ -5271,7 +5491,7 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-5.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
@@ -5279,13 +5499,13 @@
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
@@ -5294,19 +5514,19 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
@@ -5315,7 +5535,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
         "number-is-nan": "^1.0.0"
@@ -5323,13 +5543,13 @@
     },
     "is-generator-function": {
       "version": "1.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-generator-function/-/is-generator-function-1.0.7.tgz",
       "integrity": "sha1-0hMuUpuwAAp/gHlNS99c1eWBNSI=",
       "dev": true
     },
     "is-glob": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
@@ -5338,7 +5558,7 @@
     },
     "is-installed-globally": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
@@ -5348,13 +5568,13 @@
     },
     "is-npm": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
       "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
@@ -5363,7 +5583,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -5374,13 +5594,13 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
     "is-observable": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-observable/-/is-observable-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-observable/-/is-observable-1.1.0.tgz",
       "integrity": "sha1-s+mGyPRN6VCGfKtUA/WjRlAFl14=",
       "dev": true,
       "requires": {
@@ -5389,7 +5609,7 @@
       "dependencies": {
         "symbol-observable": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.2.0.tgz",
           "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ=",
           "dev": true
         }
@@ -5397,13 +5617,13 @@
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
       "dev": true,
       "requires": {
@@ -5412,7 +5632,7 @@
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
@@ -5421,13 +5641,13 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
@@ -5436,31 +5656,31 @@
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-primitive/-/is-primitive-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-promise/-/is-promise-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-redirect/-/is-redirect-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
@@ -5469,19 +5689,19 @@
     },
     "is-retry-allowed": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
       "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-symbol/-/is-symbol-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
       "dev": true,
       "requires": {
@@ -5490,57 +5710,57 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "is-valid-glob": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
       "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
     },
     "isarray": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "issue-regex": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/issue-regex/-/issue-regex-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/issue-regex/-/issue-regex-2.0.0.tgz",
       "integrity": "sha1-uxgCSQOU+Ag8emeHJHy/l1Y4710=",
       "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
@@ -5556,51 +5776,51 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json3/-/json3-3.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
     "json5": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json5/-/json5-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json5/-/json5-2.1.0.tgz",
       "integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
       "dev": true,
       "requires": {
@@ -5609,13 +5829,13 @@
     },
     "jsonschema": {
       "version": "1.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsonschema/-/jsonschema-1.2.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsonschema/-/jsonschema-1.2.4.tgz",
       "integrity": "sha1-pGusXTUGolRGW8VIh24mfG0NZGQ=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -5626,13 +5846,13 @@
     },
     "kind-of": {
       "version": "6.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-6.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
       "dev": true
     },
     "kuler": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kuler/-/kuler-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kuler/-/kuler-1.0.1.tgz",
       "integrity": "sha1-73x4TzbJ+24W3TFQ0VJneysCKKY=",
       "dev": true,
       "requires": {
@@ -5641,7 +5861,7 @@
     },
     "latest-version": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
@@ -5650,7 +5870,7 @@
     },
     "launchpad": {
       "version": "0.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/launchpad/-/launchpad-0.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/launchpad/-/launchpad-0.7.2.tgz",
       "integrity": "sha1-iN6JfX+eZkzauUpoD9FHC1i/XzE=",
       "dev": true,
       "optional": true,
@@ -5664,18 +5884,18 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.2.tgz",
-          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
+          "version": "2.6.3",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
           "dev": true,
           "optional": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
           }
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "optional": true,
@@ -5685,7 +5905,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
@@ -5694,7 +5914,7 @@
     },
     "lazystream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lazystream/-/lazystream-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
@@ -5703,7 +5923,7 @@
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lcid/-/lcid-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
@@ -5712,12 +5932,12 @@
     },
     "lightercollective": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lightercollective/-/lightercollective-0.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lightercollective/-/lightercollective-0.3.0.tgz",
       "integrity": "sha1-HwdjhkLsZF1wvbaasnd2dvNaKPA="
     },
     "listr": {
       "version": "0.14.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr/-/listr-0.14.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr/-/listr-0.14.3.tgz",
       "integrity": "sha1-L+qQlgTkNL5GTFC926DUlpKPpYY=",
       "dev": true,
       "requires": {
@@ -5734,7 +5954,7 @@
       "dependencies": {
         "p-map": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU=",
           "dev": true
         }
@@ -5742,7 +5962,7 @@
     },
     "listr-input": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-input/-/listr-input-0.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-input/-/listr-input-0.1.3.tgz",
       "integrity": "sha1-DDE5Z7bReevpZKgek2POKlo50lw=",
       "dev": true,
       "requires": {
@@ -5753,13 +5973,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "inquirer": {
           "version": "3.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-3.3.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-3.3.0.tgz",
           "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
           "dev": true,
           "requires": {
@@ -5781,13 +6001,13 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "rxjs": {
           "version": "5.5.12",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rxjs/-/rxjs-5.5.12.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rxjs/-/rxjs-5.5.12.tgz",
           "integrity": "sha1-b6YbinfD15PbrycL7i9D9lLXQcw=",
           "dev": true,
           "requires": {
@@ -5796,7 +6016,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -5806,7 +6026,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -5817,13 +6037,13 @@
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
       "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
       "dev": true
     },
     "listr-update-renderer": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
       "integrity": "sha1-Tqg2hUinuK7LfgbYyVy0WuLt5qI=",
       "dev": true,
       "requires": {
@@ -5839,13 +6059,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5858,7 +6078,7 @@
         },
         "figures": {
           "version": "1.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-1.7.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
@@ -5868,7 +6088,7 @@
         },
         "log-symbols": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-1.0.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
@@ -5877,7 +6097,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -5885,7 +6105,7 @@
     },
     "listr-verbose-renderer": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
       "integrity": "sha1-8RMhZ1NepMEmEQK58o2sfLoeA9s=",
       "dev": true,
       "requires": {
@@ -5897,7 +6117,7 @@
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
@@ -5909,7 +6129,7 @@
     },
     "locate-path": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
@@ -5918,13 +6138,13 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+      "version": "4.17.15",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
@@ -5934,43 +6154,43 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.create": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.create/-/lodash.create-3.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
@@ -5981,37 +6201,49 @@
     },
     "lodash.defaults": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
@@ -6022,44 +6254,50 @@
     },
     "lodash.padend": {
       "version": "4.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
     "lodash.some": {
       "version": "4.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.some/-/lodash.some-4.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
       "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.template": {
-      "version": "4.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.template/-/lodash.template-4.4.0.tgz",
-      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "version": "4.5.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
-      "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "version": "4.2.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+      "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-2.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
       "dev": true,
       "requires": {
@@ -6068,7 +6306,7 @@
     },
     "log-update": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-update/-/log-update-2.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-update/-/log-update-2.3.0.tgz",
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "dev": true,
       "requires": {
@@ -6079,19 +6317,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -6101,7 +6339,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -6110,7 +6348,7 @@
         },
         "wrap-ansi": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
           "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "dev": true,
           "requires": {
@@ -6122,7 +6360,7 @@
     },
     "logform": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/logform/-/logform-1.10.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/logform/-/logform-1.10.0.tgz",
       "integrity": "sha1-ydVZhxTJK1RuI/TngUfEDx4CAS4=",
       "dev": true,
       "requires": {
@@ -6135,13 +6373,13 @@
     },
     "lolex": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-1.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "dev": true,
       "requires": {
@@ -6150,7 +6388,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -6160,19 +6398,19 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
       "dev": true
     },
     "lru-cache": {
       "version": "4.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
       "dev": true,
       "requires": {
@@ -6182,7 +6420,7 @@
     },
     "magic-string": {
       "version": "0.22.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/magic-string/-/magic-string-0.22.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha1-jpz1r930Q4XB2lvCpqDb0QsDZX4=",
       "dev": true,
       "requires": {
@@ -6191,7 +6429,7 @@
     },
     "make-dir": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
       "dev": true,
       "requires": {
@@ -6200,19 +6438,19 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-obj": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-2.0.0.tgz",
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -6221,7 +6459,7 @@
     },
     "matcher": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/matcher/-/matcher-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/matcher/-/matcher-1.1.1.tgz",
       "integrity": "sha1-UdgwHhOPhAmCszixFrsMCa9iwcI=",
       "dev": true,
       "requires": {
@@ -6230,13 +6468,13 @@
     },
     "math-random": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/math-random/-/math-random-1.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/math-random/-/math-random-1.0.4.tgz",
       "integrity": "sha1-XdaUPJOFSCZwFtTjTwV1gwgMUUw=",
       "dev": true
     },
     "md5": {
       "version": "2.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/md5/-/md5-2.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "dev": true,
       "requires": {
@@ -6247,13 +6485,13 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "mem": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mem/-/mem-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
@@ -6262,7 +6500,7 @@
     },
     "meow": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/meow/-/meow-5.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/meow/-/meow-5.0.0.tgz",
       "integrity": "sha1-38c9Y6mvxxSl43F2DrXIi5EHiqQ=",
       "dev": true,
       "requires": {
@@ -6279,7 +6517,7 @@
       "dependencies": {
         "yargs-parser": {
           "version": "10.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-10.1.0.tgz",
           "integrity": "sha1-cgImW4n36eny5XZeD+c1qQXtuqg=",
           "dev": true,
           "requires": {
@@ -6290,13 +6528,13 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
     "merge-stream": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
@@ -6305,18 +6543,18 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/methods/-/methods-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "microbuffer": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/microbuffer/-/microbuffer-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/microbuffer/-/microbuffer-1.0.0.tgz",
       "integrity": "sha1-izgy7UDIfVH0e7I0kTppinVtGdI="
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-3.1.10.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "dev": true,
       "requires": {
@@ -6337,18 +6575,18 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-1.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-1.6.0.tgz",
       "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
       "dev": true
     },
     "mime-db": {
       "version": "1.40.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime-db/-/mime-db-1.40.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime-db/-/mime-db-1.40.0.tgz",
       "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI="
     },
     "mime-types": {
       "version": "2.1.24",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime-types/-/mime-types-2.1.24.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
       "requires": {
         "mime-db": "1.40.0"
@@ -6356,19 +6594,19 @@
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
       "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -6376,7 +6614,7 @@
     },
     "minimatch-all": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimatch-all/-/minimatch-all-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimatch-all/-/minimatch-all-1.1.0.tgz",
       "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
       "dev": true,
       "requires": {
@@ -6385,12 +6623,12 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist-options/-/minimist-options-3.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist-options/-/minimist-options-3.0.2.tgz",
       "integrity": "sha1-+6TIGRM54T7PTWG+sD8HAQPz2VQ=",
       "dev": true,
       "requires": {
@@ -6399,9 +6637,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+      "version": "1.3.2",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -6410,7 +6648,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -6421,7 +6659,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -6429,14 +6667,14 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
     "mocha": {
       "version": "3.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mocha/-/mocha-3.5.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mocha/-/mocha-3.5.3.tgz",
       "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
       "dev": true,
       "requires": {
@@ -6456,7 +6694,7 @@
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.9.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
@@ -6465,7 +6703,7 @@
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.8.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
           "requires": {
@@ -6474,7 +6712,7 @@
         },
         "glob": {
           "version": "7.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
@@ -6488,25 +6726,25 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "he": {
           "version": "1.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.1.1.tgz",
           "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "supports-color": {
           "version": "3.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
@@ -6517,20 +6755,20 @@
     },
     "mout": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mout/-/mout-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mout/-/mout-1.1.0.tgz",
       "integrity": "sha1-CynUHmqA+p4tSlvp1gLh2dAhd/Y=",
       "dev": true
     },
     "ms": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
       "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "multer": {
-      "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multer/-/multer-1.4.1.tgz",
-      "integrity": "sha1-JLEqQWoi/sKt6BBTkYS/E4cgFZ4=",
+      "version": "1.4.2",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multer/-/multer-1.4.2.tgz",
+      "integrity": "sha1-Lx9NEtuu66dMs35iPyNL9NPSBXo=",
       "dev": true,
       "requires": {
         "append-field": "^1.0.0",
@@ -6545,12 +6783,12 @@
     },
     "multi-clamp": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multi-clamp/-/multi-clamp-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multi-clamp/-/multi-clamp-1.1.0.tgz",
       "integrity": "sha1-nQeOMJYXSi+5CGp7fPGdFcNBWGI="
     },
     "multipipe": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multipipe/-/multipipe-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multipipe/-/multipipe-1.0.2.tgz",
       "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
       "dev": true,
       "requires": {
@@ -6560,13 +6798,13 @@
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "mz": {
       "version": "2.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mz/-/mz-2.7.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mz/-/mz-2.7.0.tgz",
       "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
       "dev": true,
       "requires": {
@@ -6577,12 +6815,12 @@
     },
     "nan": {
       "version": "2.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nan/-/nan-2.14.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nan/-/nan-2.14.0.tgz",
       "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw="
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
@@ -6601,13 +6839,13 @@
     },
     "native-promise-only": {
       "version": "0.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
     "neatequal": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/neatequal/-/neatequal-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/neatequal/-/neatequal-1.0.0.tgz",
       "integrity": "sha1-LuEhG8n6bkxVcV/SELsFYC6xrjs=",
       "requires": {
         "varstream": "^0.3.2"
@@ -6615,24 +6853,24 @@
     },
     "negotiator": {
       "version": "0.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/negotiator/-/negotiator-0.6.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs=",
       "dev": true
     },
     "neo-async": {
       "version": "2.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/neo-async/-/neo-async-2.6.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw="
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nice-try/-/nice-try-1.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/no-case/-/no-case-2.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "dev": true,
       "requires": {
@@ -6641,7 +6879,7 @@
     },
     "node-gyp": {
       "version": "3.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/node-gyp/-/node-gyp-3.8.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/node-gyp/-/node-gyp-3.8.0.tgz",
       "integrity": "sha1-VAMEJhwzDoDQ1e3OJTpoyzlkIYw=",
       "requires": {
         "fstream": "^1.0.0",
@@ -6660,7 +6898,7 @@
     },
     "nomnom": {
       "version": "1.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nomnom/-/nomnom-1.8.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nomnom/-/nomnom-1.8.1.tgz",
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
@@ -6670,13 +6908,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-1.0.0.tgz",
           "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
           "dev": true
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -6687,13 +6925,13 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         },
         "underscore": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
@@ -6701,7 +6939,7 @@
     },
     "noms": {
       "version": "0.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/noms/-/noms-0.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/noms/-/noms-0.0.0.tgz",
       "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
       "dev": true,
       "requires": {
@@ -6711,7 +6949,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -6725,7 +6963,7 @@
     },
     "nopt": {
       "version": "3.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nopt/-/nopt-3.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
         "abbrev": "1"
@@ -6733,7 +6971,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
@@ -6745,7 +6983,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
@@ -6754,7 +6992,7 @@
     },
     "np": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/np/-/np-3.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/np/-/np-3.0.4.tgz",
       "integrity": "sha1-zM0f1VvBrqWyKyq17pboJzubvdU=",
       "dev": true,
       "requires": {
@@ -6782,7 +7020,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "6.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
           "dev": true,
           "requires": {
@@ -6795,7 +7033,7 @@
           "dependencies": {
             "semver": {
               "version": "5.7.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.0.tgz",
+              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.0.tgz",
               "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=",
               "dev": true
             }
@@ -6803,7 +7041,7 @@
         },
         "execa": {
           "version": "0.10.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-0.10.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-0.10.0.tgz",
           "integrity": "sha1-/0Vqj1P5D47MxxqW0Rvfx/CCy1A=",
           "dev": true,
           "requires": {
@@ -6820,7 +7058,7 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
@@ -6829,7 +7067,7 @@
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npmlog/-/npmlog-4.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -6840,28 +7078,28 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-component/-/object-component-0.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -6872,7 +7110,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -6881,7 +7119,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -6892,22 +7130,34 @@
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
       }
     },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
     "object.entries": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.entries/-/object.entries-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
       "dev": true,
       "requires": {
@@ -6919,7 +7169,7 @@
     },
     "object.omit": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.omit/-/object.omit-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
@@ -6929,7 +7179,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -6938,13 +7188,13 @@
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/obuf/-/obuf-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4=",
       "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -6953,13 +7203,13 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/on-headers/-/on-headers-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8=",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/once/-/once-1.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -6967,13 +7217,13 @@
     },
     "one-time": {
       "version": "0.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/one-time/-/one-time-0.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=",
       "dev": true
     },
     "onetime": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
@@ -6982,13 +7232,13 @@
     },
     "opener": {
       "version": "1.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opener/-/opener-1.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opener/-/opener-1.4.3.tgz",
       "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
       "dev": true
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opn/-/opn-3.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "dev": true,
       "requires": {
@@ -6997,7 +7247,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
         "minimist": "~0.0.1",
@@ -7006,14 +7256,14 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         }
       }
     },
     "ordered-read-streams": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "dev": true,
       "requires": {
@@ -7023,12 +7273,12 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-locale/-/os-locale-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
       "dev": true,
       "requires": {
@@ -7039,12 +7289,12 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/osenv/-/osenv-0.1.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
       "requires": {
         "os-homedir": "^1.0.0",
@@ -7053,13 +7303,13 @@
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-1.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "dev": true,
       "requires": {
@@ -7068,7 +7318,7 @@
     },
     "p-locate": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
@@ -7077,13 +7327,13 @@
     },
     "p-map": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
       "dev": true
     },
     "p-timeout": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-timeout/-/p-timeout-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-timeout/-/p-timeout-2.0.1.tgz",
       "integrity": "sha1-2N0ZeVldLcATnh/ka4tkbLPN8Dg=",
       "dev": true,
       "requires": {
@@ -7092,13 +7342,13 @@
     },
     "p-try": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-try/-/p-try-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "package-json": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
@@ -7110,12 +7360,12 @@
     },
     "pako": {
       "version": "1.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pako/-/pako-1.0.10.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pako/-/pako-1.0.10.tgz",
       "integrity": "sha1-Qyi621CGpCaqkPVBl31JVdpclzI="
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/param-case/-/param-case-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
@@ -7124,7 +7374,7 @@
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-glob/-/parse-glob-3.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
@@ -7136,13 +7386,13 @@
       "dependencies": {
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
@@ -7153,7 +7403,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -7161,21 +7411,27 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "parse-node-version": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha1-4rXb7eAOf6m8NjYH9TMn6LBzGJs=",
+      "dev": true
+    },
     "parse-passwd": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "parse5": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
       "dev": true
     },
     "parseqs": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseqs/-/parseqs-0.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
@@ -7184,7 +7440,7 @@
     },
     "parseuri": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseuri/-/parseuri-0.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
@@ -7193,60 +7449,60 @@
     },
     "parseurl": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-parse/-/path-parse-1.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
       "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
     "path-type": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-type/-/path-type-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
       "dev": true,
       "requires": {
@@ -7255,7 +7511,7 @@
     },
     "pem": {
       "version": "1.14.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pem/-/pem-1.14.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pem/-/pem-1.14.2.tgz",
       "integrity": "sha1-qyk1BBa8OlMsML7u4NVBr4l/uaw=",
       "dev": true,
       "requires": {
@@ -7267,31 +7523,31 @@
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pend/-/pend-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true,
       "optional": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -7300,7 +7556,7 @@
     },
     "plist": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plist/-/plist-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plist/-/plist-2.1.0.tgz",
       "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
       "dev": true,
       "optional": true,
@@ -7310,9 +7566,21 @@
         "xmldom": "0.1.x"
       }
     },
+    "plugin-error": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha1-dwFr2JGdCsN3/c3QMiMolTyleBw=",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^1.0.1",
+        "arr-diff": "^4.0.0",
+        "arr-union": "^3.1.0",
+        "extend-shallow": "^3.0.2"
+      }
+    },
     "plylog": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plylog/-/plylog-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plylog/-/plylog-1.1.0.tgz",
       "integrity": "sha1-9vNU4q4LAfbbTtER9LOFXanDdBc=",
       "dev": true,
       "requires": {
@@ -7322,9 +7590,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-analyzer/-/polymer-analyzer-3.2.3.tgz",
-      "integrity": "sha1-YKDsbNp+XBb+Qpn8GT0QAIKaEaY=",
+      "version": "3.2.4",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-analyzer/-/polymer-analyzer-3.2.4.tgz",
+      "integrity": "sha1-fXY1ZiCiMo6LyeMORwaflykmDKE=",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.0.0-beta.42",
@@ -7368,13 +7636,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -7387,7 +7655,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -7395,7 +7663,7 @@
     },
     "polymer-build": {
       "version": "3.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-build/-/polymer-build-3.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-build/-/polymer-build-3.1.4.tgz",
       "integrity": "sha1-q1OfGhPYA1GLE7c//QkZhDHZgUI=",
       "dev": true,
       "requires": {
@@ -7468,7 +7736,7 @@
       "dependencies": {
         "@types/mz": {
           "version": "0.0.31",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.31.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.31.tgz",
           "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
           "dev": true,
           "requires": {
@@ -7477,7 +7745,7 @@
         },
         "@types/resolve": {
           "version": "0.0.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.7.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.7.tgz",
           "integrity": "sha1-spnBO+jXErG1AvsUoIQlKs74T00=",
           "dev": true,
           "requires": {
@@ -7488,7 +7756,7 @@
     },
     "polymer-bundler": {
       "version": "4.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-bundler/-/polymer-bundler-4.0.10.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-bundler/-/polymer-bundler-4.0.10.tgz",
       "integrity": "sha1-q8jTOXdlLwMQaNA0yBBIQegNTLs=",
       "dev": true,
       "requires": {
@@ -7513,7 +7781,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -7521,7 +7789,7 @@
     },
     "polymer-project-config": {
       "version": "4.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-project-config/-/polymer-project-config-4.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-project-config/-/polymer-project-config-4.0.3.tgz",
       "integrity": "sha1-7wwaZ2zkgJkHmGyOkQdFZg3oAk8=",
       "dev": true,
       "requires": {
@@ -7535,7 +7803,7 @@
     },
     "polyserve": {
       "version": "0.27.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polyserve/-/polyserve-0.27.15.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polyserve/-/polyserve-0.27.15.tgz",
       "integrity": "sha1-Jh+loIc8jZX9cGhZj0TJ2sIM+cQ=",
       "dev": true,
       "requires": {
@@ -7577,16 +7845,16 @@
       "dependencies": {
         "mime": {
           "version": "2.4.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-2.4.4.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-2.4.4.tgz",
           "integrity": "sha1-vXuRE1/GsBzePpuuM9ZZtj2IV+U=",
           "dev": true
         }
       }
     },
     "portfinder": {
-      "version": "1.0.20",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/portfinder/-/portfinder-1.0.20.tgz",
-      "integrity": "sha1-vqaGMuVLLhOrewxHdem0G/Jw5Eo=",
+      "version": "1.0.21",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/portfinder/-/portfinder-1.0.21.tgz",
+      "integrity": "sha1-YOE5e5WsFwdJ23ADTs4wa5on4yQ=",
       "dev": true,
       "requires": {
         "async": "^1.5.2",
@@ -7596,7 +7864,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -7605,7 +7873,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -7613,25 +7881,25 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-1.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/preserve/-/preserve-0.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
@@ -7646,30 +7914,30 @@
     },
     "private": {
       "version": "0.1.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/private/-/private-0.1.8.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/private/-/private-0.1.8.tgz",
       "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
       "dev": true
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
+      "version": "2.0.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/progress/-/progress-2.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/progress/-/progress-2.0.3.tgz",
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
       "dev": true,
       "optional": true
     },
     "promise-polyfill": {
       "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/promise-polyfill/-/promise-polyfill-7.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/promise-polyfill/-/promise-polyfill-7.0.0.tgz",
       "integrity": "sha1-xmW22h+X4hw/L3qgVDyQIJEnyxU="
     },
     "proxy-addr": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/proxy-addr/-/proxy-addr-2.0.5.tgz",
       "integrity": "sha1-NMvWSi2B9LH9IedvnwbIpFKZ7jQ=",
       "dev": true,
       "requires": {
@@ -7679,39 +7947,39 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "psl": {
-      "version": "1.1.32",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha1-PxMnF88vnBaXJLK2yvNzz2lBmNs="
+      "version": "1.2.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha1-3xK1sbOjD1HDKerL3vmPOm4TbcY="
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/q/-/q-1.5.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.5.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.5.2.tgz",
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
     },
     "quick-lru": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/quick-lru/-/quick-lru-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/quick-lru/-/quick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
     "randomatic": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/randomatic/-/randomatic-3.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/randomatic/-/randomatic-3.1.1.tgz",
       "integrity": "sha1-t3bvxZN1mE42xTey9RofCv8Noe0=",
       "dev": true,
       "requires": {
@@ -7722,7 +7990,7 @@
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-4.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-4.0.0.tgz",
           "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
           "dev": true
         }
@@ -7730,13 +7998,13 @@
     },
     "range-parser": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
       "dev": true
     },
     "raw-body": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/raw-body/-/raw-body-2.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
       "dev": true,
       "requires": {
@@ -7748,7 +8016,7 @@
     },
     "rc": {
       "version": "1.2.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rc/-/rc-1.2.8.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rc/-/rc-1.2.8.tgz",
       "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "dev": true,
       "requires": {
@@ -7760,7 +8028,7 @@
     },
     "read-pkg": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
@@ -7771,7 +8039,7 @@
     },
     "read-pkg-up": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
       "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
       "dev": true,
       "requires": {
@@ -7781,7 +8049,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -7795,12 +8063,12 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -7810,7 +8078,7 @@
     },
     "redent": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redent/-/redent-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redent/-/redent-2.0.0.tgz",
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
@@ -7820,19 +8088,19 @@
     },
     "reduce-flatten": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
       "dev": true
     },
     "regenerate": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerate/-/regenerate-1.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerate/-/regenerate-1.4.0.tgz",
       "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
       "dev": true
     },
     "regenerate-unicode-properties": {
       "version": "8.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
       "integrity": "sha1-71Hg8OpK1CS3e/fLQfPgFccKPw4=",
       "dev": true,
       "requires": {
@@ -7841,14 +8109,14 @@
     },
     "regenerator-runtime": {
       "version": "0.11.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
       "dev": true
     },
     "regenerator-transform": {
-      "version": "0.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
-      "integrity": "sha1-LKmq96LCOd0y5HYSGEJbjHqG7K8=",
+      "version": "0.14.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "integrity": "sha1-Oy/OThq3cywI9mXf2zFHScfd0vs=",
       "dev": true,
       "requires": {
         "private": "^0.1.6"
@@ -7856,7 +8124,7 @@
     },
     "regex-cache": {
       "version": "0.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regex-cache/-/regex-cache-0.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
@@ -7865,7 +8133,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
@@ -7875,7 +8143,7 @@
     },
     "regexpu-core": {
       "version": "4.5.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regexpu-core/-/regexpu-core-4.5.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regexpu-core/-/regexpu-core-4.5.4.tgz",
       "integrity": "sha1-CA2dAiiaqH/hZnpPUTa8mKauuq4=",
       "dev": true,
       "requires": {
@@ -7889,7 +8157,7 @@
     },
     "registry-auth-token": {
       "version": "3.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
       "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
       "dev": true,
       "requires": {
@@ -7899,7 +8167,7 @@
     },
     "registry-url": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
@@ -7908,13 +8176,13 @@
     },
     "regjsgen": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regjsgen/-/regjsgen-0.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regjsgen/-/regjsgen-0.5.0.tgz",
       "integrity": "sha1-p2NNwI+JIJwgSa3aNSVxH7lyZd0=",
       "dev": true
     },
     "regjsparser": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regjsparser/-/regjsparser-0.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regjsparser/-/regjsparser-0.6.0.tgz",
       "integrity": "sha1-8eaui32iuulsmTmbhozWyTOiupw=",
       "dev": true,
       "requires": {
@@ -7923,7 +8191,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -7931,31 +8199,31 @@
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/relateurl/-/relateurl-0.2.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeat-element/-/repeat-element-1.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -7964,7 +8232,7 @@
     },
     "replace": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/replace/-/replace-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/replace/-/replace-1.0.0.tgz",
       "integrity": "sha1-2lI1zG1k1cOnTk73O0h6rQ95p0s=",
       "dev": true,
       "requires": {
@@ -7975,7 +8243,7 @@
       "dependencies": {
         "colors": {
           "version": "1.2.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colors/-/colors-1.2.4.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colors/-/colors-1.2.4.tgz",
           "integrity": "sha1-4MtB0+SyCAazv8J/RVnwG5S8L3w=",
           "dev": true
         }
@@ -7983,13 +8251,13 @@
     },
     "replace-ext": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/replace-ext/-/replace-ext-0.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
     "request": {
       "version": "2.88.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request/-/request-2.88.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request/-/request-2.88.0.tgz",
       "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -8016,32 +8284,32 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "requirejs": {
       "version": "2.3.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/requirejs/-/requirejs-2.3.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/requirejs/-/requirejs-2.3.6.tgz",
       "integrity": "sha1-5Qk9lgHCgpJRJYwLlEXU0Z+p58k=",
       "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
-      "version": "1.11.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve/-/resolve-1.11.0.tgz",
-      "integrity": "sha1-QBSHC6KWF2uGND1Qtg87UGCc4jI=",
+      "version": "1.11.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha1-6hDYEQN2mC/vV434/DC5rDCgej4=",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -8049,7 +8317,7 @@
     },
     "resolve-dir": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
@@ -8059,13 +8327,13 @@
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "restore-cursor": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
@@ -8075,40 +8343,40 @@
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ret/-/ret-0.1.15.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
     "rimraf": {
       "version": "2.6.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
       "requires": {
         "glob": "^7.1.3"
       }
     },
     "rollup": {
-      "version": "1.15.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rollup/-/rollup-1.15.2.tgz",
-      "integrity": "sha1-Z2/rDnPI+Z914AeLMxpXbFY1TfY=",
+      "version": "1.17.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rollup/-/rollup-1.17.0.tgz",
+      "integrity": "sha1-R+6LBFFFRPyTs5uuBicSRMjbffo=",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "^12.0.8",
-        "acorn": "^6.1.1"
+        "@types/node": "^12.6.2",
+        "acorn": "^6.2.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "6.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-6.1.1.tgz",
-          "integrity": "sha1-fSWuBbuK0fm2mRCOEJTs14hK3B8=",
+          "version": "6.2.1",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-6.2.1.tgz",
+          "integrity": "sha1-PthCLW3sCeYSHMeoQ8qGozCoa1E=",
           "dev": true
         }
       }
     },
     "run-async": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/run-async/-/run-async-2.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
@@ -8117,13 +8385,13 @@
     },
     "rx-lite": {
       "version": "4.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rx-lite/-/rx-lite-4.0.8.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
       "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
@@ -8132,7 +8400,7 @@
     },
     "rxjs": {
       "version": "6.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rxjs/-/rxjs-6.5.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rxjs/-/rxjs-6.5.2.tgz",
       "integrity": "sha1-LjXOgVzUbYTQKiCftOWSHgUdvsc=",
       "dev": true,
       "requires": {
@@ -8141,12 +8409,12 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -8155,18 +8423,18 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "samsam": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/samsam/-/samsam-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
     "sauce-connect-launcher": {
       "version": "1.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sauce-connect-launcher/-/sauce-connect-launcher-1.2.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sauce-connect-launcher/-/sauce-connect-launcher-1.2.7.tgz",
       "integrity": "sha1-x/iz1Os1TQepkitM1nNW9ScZJVY=",
       "dev": true,
       "optional": true,
@@ -8179,20 +8447,20 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.2.tgz",
-          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
+          "version": "2.6.3",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
           "dev": true,
           "optional": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
           }
         }
       }
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sax/-/sax-1.2.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sax/-/sax-1.2.4.tgz",
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "select": {
@@ -8204,13 +8472,13 @@
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/select-hose/-/select-hose-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
     "selenium-standalone": {
       "version": "6.16.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/selenium-standalone/-/selenium-standalone-6.16.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/selenium-standalone/-/selenium-standalone-6.16.0.tgz",
       "integrity": "sha1-/88CZlxY/3p0ckJ66Bm6ecFZZ6w=",
       "dev": true,
       "optional": true,
@@ -8231,18 +8499,18 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.2.tgz",
-          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
+          "version": "2.6.3",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
           "dev": true,
           "optional": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
           }
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
           "dev": true,
           "optional": true,
@@ -8256,7 +8524,7 @@
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "optional": true,
@@ -8266,7 +8534,7 @@
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.0.tgz",
           "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=",
           "dev": true,
           "optional": true
@@ -8275,12 +8543,12 @@
     },
     "semver": {
       "version": "5.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.3.0.tgz",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "semver-diff": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
@@ -8289,7 +8557,7 @@
     },
     "send": {
       "version": "0.16.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.16.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.16.2.tgz",
       "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
       "dev": true,
       "requires": {
@@ -8310,7 +8578,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -8319,7 +8587,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
@@ -8329,27 +8597,33 @@
             "statuses": ">= 1.4.0 < 2"
           }
         },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
         "mime": {
           "version": "1.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-1.4.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-1.4.1.tgz",
           "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
           "dev": true
         },
         "statuses": {
           "version": "1.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/statuses/-/statuses-1.4.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic=",
           "dev": true
         }
@@ -8357,7 +8631,7 @@
     },
     "serve-static": {
       "version": "1.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serve-static/-/serve-static-1.14.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
       "dev": true,
       "requires": {
@@ -8369,7 +8643,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -8378,7 +8652,7 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             }
@@ -8386,13 +8660,13 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
           "dev": true
         },
         "send": {
           "version": "0.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
           "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
           "dev": true,
           "requires": {
@@ -8415,25 +8689,25 @@
     },
     "server-destroy": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/server-destroy/-/server-destroy-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
       "dev": true
     },
     "serviceworker-cache-polyfill": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
       "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves=",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+      "version": "2.0.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -8444,7 +8718,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -8455,19 +8729,19 @@
     },
     "setprototypeof": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
       "dev": true
     },
     "shady-css-parser": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha1-U03HnIyliExe2SpOWhPW2GO8pCg=",
       "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -8476,18 +8750,18 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
@@ -8496,7 +8770,7 @@
       "dependencies": {
         "is-arrayish": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
           "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM=",
           "dev": true
         }
@@ -8504,7 +8778,7 @@
     },
     "sinon": {
       "version": "1.17.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-1.17.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true,
       "requires": {
@@ -8516,19 +8790,19 @@
     },
     "sinon-chai": {
       "version": "2.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon-chai/-/sinon-chai-2.14.0.tgz",
       "integrity": "sha1-2n3UzIPNaiYLZ8yg96n9riahIF0=",
       "dev": true
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
@@ -8544,7 +8818,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -8553,7 +8827,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -8562,7 +8836,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -8571,13 +8845,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -8585,7 +8859,7 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
@@ -8596,7 +8870,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -8605,7 +8879,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -8614,7 +8888,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -8623,7 +8897,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -8636,7 +8910,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
@@ -8645,7 +8919,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -8656,7 +8930,7 @@
     },
     "socket.io": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io/-/socket.io-2.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io/-/socket.io-2.2.0.tgz",
       "integrity": "sha1-8PYzFh72cSyXKzB1mOzQjJsbTVs=",
       "dev": true,
       "requires": {
@@ -8670,7 +8944,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -8681,13 +8955,13 @@
     },
     "socket.io-adapter": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
       "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
       "dev": true
     },
     "socket.io-client": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-client/-/socket.io-client-2.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-client/-/socket.io-client-2.2.0.tgz",
       "integrity": "sha1-hOc+48Q9UCDMwaJY+u65rsJyOvc=",
       "dev": true,
       "requires": {
@@ -8709,13 +8983,13 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
           "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
@@ -8724,7 +8998,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -8732,7 +9006,7 @@
     },
     "socket.io-parser": {
       "version": "3.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
       "integrity": "sha1-K1KpalCf3zFEC6QP7WCUx9TxJi8=",
       "dev": true,
       "requires": {
@@ -8743,13 +9017,13 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
           "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
@@ -8758,13 +9032,13 @@
         },
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -8772,12 +9046,12 @@
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
     },
     "source-map-resolve": {
       "version": "0.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
       "dev": true,
       "requires": {
@@ -8790,13 +9064,13 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "dev": true,
       "requires": {
@@ -8806,13 +9080,13 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
@@ -8821,14 +9095,14 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha1-dezRqI3owYTvAV6vtRtbSL/RG7E=",
+      "version": "3.0.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
     "spdy": {
       "version": "3.4.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdy/-/spdy-3.4.7.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "dev": true,
       "requires": {
@@ -8842,7 +9116,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -8851,7 +9125,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -8859,7 +9133,7 @@
     },
     "spdy-transport": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdy-transport/-/spdy-transport-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdy-transport/-/spdy-transport-2.1.1.tgz",
       "integrity": "sha1-xUgV1zhYqt0GzmMAHn0l+mRBYjs=",
       "dev": true,
       "requires": {
@@ -8874,7 +9148,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -8883,7 +9157,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -8891,7 +9165,7 @@
     },
     "split": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/split/-/split-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/split/-/split-1.0.1.tgz",
       "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "dev": true,
       "requires": {
@@ -8900,7 +9174,7 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
@@ -8909,12 +9183,12 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "requires": {
         "asn1": "~0.2.3",
@@ -8930,19 +9204,19 @@
     },
     "stable": {
       "version": "0.1.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stable/-/stable-0.1.8.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stable/-/stable-0.1.8.tgz",
       "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
       "dev": true
     },
     "stack-trace": {
       "version": "0.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stack-trace/-/stack-trace-0.0.10.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
     "stacky": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stacky/-/stacky-1.3.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stacky/-/stacky-1.3.1.tgz",
       "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
       "dev": true,
       "requires": {
@@ -8952,13 +9226,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -8971,13 +9245,13 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -8985,7 +9259,7 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -8995,7 +9269,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -9006,13 +9280,13 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
     "stream": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream/-/stream-0.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream/-/stream-0.0.2.tgz",
       "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
       "dev": true,
       "requires": {
@@ -9021,19 +9295,19 @@
     },
     "stream-shift": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream-shift/-/stream-shift-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
     "streamsearch": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/streamsearch/-/streamsearch-0.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
       "dev": true
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
@@ -9043,22 +9317,22 @@
     },
     "string.fromcodepoint": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
       "integrity": "sha1-jZeDM8C8klOPUPOD5IiPPlYZ1lM="
     },
     "string.prototype.codepointat": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
       "integrity": "sha1-AErUTIr8cnUnsQjNRitNlxzUabw="
     },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -9066,13 +9340,13 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-bom-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
       "requires": {
@@ -9082,7 +9356,7 @@
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
@@ -9093,25 +9367,25 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-indent": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-2.0.0.tgz",
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
@@ -9120,7 +9394,7 @@
     },
     "supports-hyperlinks": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
       "integrity": "sha1-cdrt82zBBgrFEAw1G7PaSMKcDvc=",
       "dev": true,
       "requires": {
@@ -9130,7 +9404,7 @@
       "dependencies": {
         "has-flag": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         }
@@ -9138,7 +9412,7 @@
     },
     "svg-pathdata": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svg-pathdata/-/svg-pathdata-1.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svg-pathdata/-/svg-pathdata-1.0.4.tgz",
       "integrity": "sha1-emgTQqrH7/2NUq+6eZmRDJ2juVk=",
       "requires": {
         "readable-stream": "~2.0.4"
@@ -9146,17 +9420,17 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -9171,7 +9445,7 @@
     },
     "svg2ttf": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svg2ttf/-/svg2ttf-4.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svg2ttf/-/svg2ttf-4.3.0.tgz",
       "integrity": "sha1-QzRAx+kGL4/c7DytchzQiix+UeM=",
       "requires": {
         "argparse": "^1.0.6",
@@ -9184,7 +9458,7 @@
     },
     "svgicons2svgfont": {
       "version": "5.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svgicons2svgfont/-/svgicons2svgfont-5.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svgicons2svgfont/-/svgicons2svgfont-5.0.2.tgz",
       "integrity": "sha1-BRGCPGSRvhp9VDKS4pqK5ietBAY=",
       "requires": {
         "commander": "^2.9.0",
@@ -9198,12 +9472,12 @@
     },
     "svgpath": {
       "version": "2.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svgpath/-/svgpath-2.2.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svgpath/-/svgpath-2.2.2.tgz",
       "integrity": "sha1-HHDUTif3tr1Cp07TyWC+k+QR3vM="
     },
     "sw-precache": {
       "version": "5.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sw-precache/-/sw-precache-5.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sw-precache/-/sw-precache-5.2.1.tgz",
       "integrity": "sha1-BhNPMZ7saPO5WDzppwNrHBGfcXk=",
       "dev": true,
       "requires": {
@@ -9221,13 +9495,13 @@
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-2.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -9237,7 +9511,7 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-1.1.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
@@ -9247,7 +9521,7 @@
         },
         "indent-string": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-2.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
@@ -9256,7 +9530,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -9269,13 +9543,13 @@
         },
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/meow/-/meow-3.7.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
@@ -9293,7 +9567,7 @@
         },
         "parse-json": {
           "version": "2.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-2.2.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
@@ -9302,7 +9576,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-2.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
@@ -9311,7 +9585,7 @@
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-type/-/path-type-1.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
@@ -9322,13 +9596,13 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-1.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
@@ -9339,7 +9613,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
@@ -9349,7 +9623,7 @@
         },
         "redent": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redent/-/redent-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
@@ -9359,7 +9633,7 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
@@ -9368,7 +9642,7 @@
         },
         "strip-indent": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-1.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
@@ -9377,7 +9651,7 @@
         },
         "trim-newlines": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
           "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
           "dev": true
         }
@@ -9385,7 +9659,7 @@
     },
     "sw-toolbox": {
       "version": "3.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "dev": true,
       "requires": {
@@ -9395,7 +9669,7 @@
       "dependencies": {
         "path-to-regexp": {
           "version": "1.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
           "dev": true,
           "requires": {
@@ -9406,14 +9680,14 @@
     },
     "symbol-observable": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
       "dev": true
     },
     "table-layout": {
-      "version": "0.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/table-layout/-/table-layout-0.4.4.tgz",
-      "integrity": "sha1-vFOYsqBeWLZ7Bd2SODVLie8nvg8=",
+      "version": "0.4.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/table-layout/-/table-layout-0.4.5.tgz",
+      "integrity": "sha1-2QbeaiX6CcDJDR0I7Ngz7O3Lc3g=",
       "dev": true,
       "requires": {
         "array-back": "^2.0.0",
@@ -9425,7 +9699,7 @@
       "dependencies": {
         "array-back": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
           "dev": true,
           "requires": {
@@ -9434,7 +9708,7 @@
         },
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
@@ -9442,7 +9716,7 @@
     },
     "tar": {
       "version": "2.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar/-/tar-2.2.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar/-/tar-2.2.2.tgz",
       "integrity": "sha1-DKiEhWLHKZuLRG/2pNYM27I+3EA=",
       "requires": {
         "block-stream": "*",
@@ -9452,7 +9726,7 @@
     },
     "tar-stream": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.0.0.tgz",
       "integrity": "sha1-iCm7+DBnvAKIqQidtJxWvjlbauo=",
       "dev": true,
       "optional": true,
@@ -9466,7 +9740,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.4.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha1-pRwmdUZY4KPCHb9ZFjvUW6b0R/w=",
           "dev": true,
           "optional": true,
@@ -9478,7 +9752,7 @@
         },
         "string_decoder": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.2.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.2.0.tgz",
           "integrity": "sha1-/obnOLGVRK/nBGkkOyoe6SQOro0=",
           "dev": true,
           "optional": true,
@@ -9490,7 +9764,7 @@
     },
     "temp": {
       "version": "0.8.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/temp/-/temp-0.8.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
       "optional": true,
@@ -9501,7 +9775,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true,
           "optional": true
@@ -9510,7 +9784,7 @@
     },
     "term-size": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
@@ -9519,7 +9793,7 @@
     },
     "terminal-link": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/terminal-link/-/terminal-link-1.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/terminal-link/-/terminal-link-1.3.0.tgz",
       "integrity": "sha1-PpowgonhM0AFOq9A6PGgbRM1ZG4=",
       "dev": true,
       "requires": {
@@ -9528,9 +9802,9 @@
       }
     },
     "ternary-stream": {
-      "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ternary-stream/-/ternary-stream-2.0.1.tgz",
-      "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
+      "version": "2.1.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ternary-stream/-/ternary-stream-2.1.1.tgz",
+      "integrity": "sha1-StZLmGaNeWoIWvLEk4haQ1qKi/w=",
       "dev": true,
       "requires": {
         "duplexify": "^3.5.0",
@@ -9541,24 +9815,24 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
     "text-hex": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-hex/-/text-hex-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha1-adycGxdEbueakr9biEu0uRJ1BvU=",
       "dev": true
     },
     "textfit": {
-      "version": "2.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/textfit/-/textfit-2.3.1.tgz",
-      "integrity": "sha1-WJbbSOpwp2e5enPyhVZAaHXKII8="
+      "version": "2.4.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/textfit/-/textfit-2.4.0.tgz",
+      "integrity": "sha1-gMuoAGv7nD2dVSc5JXlXvdqVx5w="
     },
     "thenify": {
       "version": "3.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/thenify/-/thenify-3.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
@@ -9567,7 +9841,7 @@
     },
     "thenify-all": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/thenify-all/-/thenify-all-1.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
@@ -9576,13 +9850,13 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through/-/through-2.3.8.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-2.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-2.0.5.tgz",
       "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "requires": {
@@ -9592,7 +9866,7 @@
     },
     "through2-filter": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
@@ -9600,9 +9874,15 @@
         "xtend": "~4.0.0"
       }
     },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true
+    },
     "timed-out": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
@@ -9615,7 +9895,7 @@
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.33.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
@@ -9624,7 +9904,7 @@
     },
     "to-absolute-glob": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
       "requires": {
@@ -9633,7 +9913,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -9644,25 +9924,19 @@
     },
     "to-array": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-array/-/to-array-0.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
-      "dev": true
-    },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -9671,7 +9945,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -9682,7 +9956,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
@@ -9694,7 +9968,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -9704,13 +9978,13 @@
     },
     "toidentifier": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/toidentifier/-/toidentifier-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM=",
       "dev": true
     },
     "tough-cookie": {
       "version": "2.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
       "requires": {
         "psl": "^1.1.24",
@@ -9719,14 +9993,14 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
@@ -9735,31 +10009,31 @@
     },
     "trim-newlines": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-2.0.0.tgz",
       "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
       "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "triple-beam": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/triple-beam/-/triple-beam-1.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha1-pZUhTHKY24M57u7gg+TRC9jLjdk=",
       "dev": true
     },
     "tslib": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tslib/-/tslib-1.10.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo=",
       "dev": true
     },
     "ttf2eot": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2eot/-/ttf2eot-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2eot/-/ttf2eot-2.0.0.tgz",
       "integrity": "sha1-jmM3pYWr0WCKDISVirSDzmn2ZUs=",
       "requires": {
         "argparse": "^1.0.6",
@@ -9768,7 +10042,7 @@
     },
     "ttf2woff": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2woff/-/ttf2woff-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2woff/-/ttf2woff-2.0.1.tgz",
       "integrity": "sha1-hxgyJAAksJ25VwkEx8GSi4BXyWk=",
       "requires": {
         "argparse": "^1.0.6",
@@ -9778,7 +10052,7 @@
     },
     "ttf2woff2": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2woff2/-/ttf2woff2-2.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2woff2/-/ttf2woff2-2.0.3.tgz",
       "integrity": "sha1-XgIK/m5kMofzrXaHq+0g/mVOsyk=",
       "requires": {
         "bindings": "^1.2.1",
@@ -9789,7 +10063,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -9797,18 +10071,18 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-detect": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-1.0.0.tgz",
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
     "type-is": {
       "version": "1.6.18",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
       "dev": true,
       "requires": {
@@ -9818,19 +10092,19 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typical": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-4.0.0.tgz",
       "integrity": "sha1-y+r/O5164eK7+vWk5vEezP3pT8Q=",
       "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.20",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
       "integrity": "sha1-dScXi4L2pioPJD0flP0w4+PCEJg=",
       "dev": true
     },
@@ -9845,7 +10119,7 @@
       "dependencies": {
         "commander": {
           "version": "2.14.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.14.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.14.1.tgz",
           "integrity": "sha1-IjUSPjevjKPGXfRbAm29NXsBuao=",
           "dev": true
         }
@@ -9853,7 +10127,7 @@
     },
     "uglify-js": {
       "version": "3.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.6.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
       "optional": true,
       "requires": {
@@ -9863,18 +10137,18 @@
     },
     "underscore": {
       "version": "1.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/underscore/-/underscore-1.9.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha1-BtzjSg5op7q8KbNluOdLiSUgOWE="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
       "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=",
       "dev": true
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
       "dev": true,
       "requires": {
@@ -9884,19 +10158,19 @@
     },
     "unicode-match-property-value-ecmascript": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
       "integrity": "sha1-W0tCbgjROoA2Xg1lesemwexGonc=",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha1-qcxsx85joKMCP8meNBuUQx1AWlc=",
       "dev": true
     },
     "union": {
       "version": "0.4.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/union/-/union-0.4.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/union/-/union-0.4.6.tgz",
       "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
       "dev": true,
       "requires": {
@@ -9905,50 +10179,27 @@
       "dependencies": {
         "qs": {
           "version": "2.3.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-2.3.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-2.3.3.tgz",
           "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
           "dev": true
         }
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-stream": {
       "version": "2.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-stream/-/unique-stream-2.3.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-stream/-/unique-stream-2.3.1.tgz",
       "integrity": "sha1-xl0RDppK35psWUiygFPZqNBMvqw=",
       "dev": true,
       "requires": {
@@ -9958,7 +10209,7 @@
       "dependencies": {
         "through2-filter": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-3.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-3.0.0.tgz",
           "integrity": "sha1-cA54bfI2fCyIzYqlvkz5weeDElQ=",
           "dev": true,
           "requires": {
@@ -9970,7 +10221,7 @@
     },
     "unique-string": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
@@ -9979,13 +10230,13 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -9995,7 +10246,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -10006,7 +10257,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -10017,13 +10268,13 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
@@ -10031,7 +10282,7 @@
     },
     "untildify": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/untildify/-/untildify-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "dev": true,
       "requires": {
@@ -10040,13 +10291,13 @@
     },
     "unzip-response": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
       "dev": true
     },
     "update-notifier": {
       "version": "2.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
       "dev": true,
       "requires": {
@@ -10064,13 +10315,13 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uri-js/-/uri-js-4.2.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "requires": {
         "punycode": "^2.1.0"
@@ -10078,24 +10329,24 @@
     },
     "urijs": {
       "version": "1.19.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/urijs/-/urijs-1.19.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/urijs/-/urijs-1.19.1.tgz",
       "integrity": "sha1-Ww/1MMDL3oOG9jQiNbpcpumV0lo=",
       "dev": true
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/urix/-/urix-0.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url-join": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-join/-/url-join-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
@@ -10104,17 +10355,17 @@
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/use/-/use-3.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/use/-/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
     "util": {
-      "version": "0.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util/-/util-0.12.0.tgz",
-      "integrity": "sha1-u149KbonA8et0K0zcAO+PKR3eYo=",
+      "version": "0.12.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util/-/util-0.12.1.tgz",
+      "integrity": "sha1-+QjntjPnOWx2TmlN0U5xYlbOit4=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
+        "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "object.entries": "^1.1.0",
@@ -10123,29 +10374,29 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uuid/-/uuid-3.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
     },
     "vali-date": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vali-date/-/vali-date-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vali-date/-/vali-date-1.0.0.tgz",
       "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
@@ -10155,13 +10406,13 @@
     },
     "vargs": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vargs/-/vargs-0.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vargs/-/vargs-0.1.0.tgz",
       "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
       "dev": true
     },
     "varstream": {
       "version": "0.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/varstream/-/varstream-0.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/varstream/-/varstream-0.3.2.tgz",
       "integrity": "sha1-GKxklHZfP/GjWtmkvgU77BiKXeE=",
       "requires": {
         "readable-stream": "^1.0.33"
@@ -10169,7 +10420,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -10182,13 +10433,13 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vary/-/vary-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/verror/-/verror-1.10.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -10198,7 +10449,7 @@
     },
     "vinyl": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vinyl/-/vinyl-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vinyl/-/vinyl-1.2.0.tgz",
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
@@ -10209,7 +10460,7 @@
       "dependencies": {
         "clone": {
           "version": "1.0.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone/-/clone-1.0.4.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone/-/clone-1.0.4.tgz",
           "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "dev": true
         }
@@ -10217,7 +10468,7 @@
     },
     "vinyl-fs": {
       "version": "2.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "dev": true,
       "requires": {
@@ -10242,7 +10493,7 @@
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
@@ -10253,7 +10504,7 @@
     },
     "vl-ui-button": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-button/-/vl-ui-button-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-button/-/vl-ui-button-1.0.3.tgz",
       "integrity": "sha1-dsYJ/SDIydnP3oqTjZxnQ768F1Y=",
       "requires": {
         "vl-ui-core": "1.3.3"
@@ -10261,7 +10512,7 @@
       "dependencies": {
         "vl-ui-core": {
           "version": "1.3.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-1.3.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-1.3.3.tgz",
           "integrity": "sha1-THkeQGS1zGdXOq021wNIsZW5krA=",
           "requires": {
             "@govflanders/vl-ui-core": "3.7.2",
@@ -10272,7 +10523,7 @@
     },
     "vl-ui-core": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-1.4.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-1.4.1.tgz",
       "integrity": "sha1-ZYv5dszpPeZyO9OhODzrwpN0OY0=",
       "requires": {
         "@govflanders/vl-ui-core": "3.7.2",
@@ -10281,16 +10532,16 @@
     },
     "vl-ui-icon": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-icon/-/vl-ui-icon-2.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-icon/-/vl-ui-icon-2.0.3.tgz",
       "integrity": "sha1-ylavqCOsRANOYyD5J9NM2rUSKRs=",
       "requires": {
         "vl-ui-core": "1.4.1"
       }
     },
     "vl-ui-util": {
-      "version": "1.1.3",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-util/-/vl-ui-util-1.1.3.tgz",
-      "integrity": "sha1-s7YJXdgWWDr+oMMGiOlbe+ypwJs=",
+      "version": "1.2.3",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-util/-/vl-ui-util-1.2.3.tgz",
+      "integrity": "sha1-cqVdf3YVibbnoysz2kGPctI/MjY=",
       "dev": true,
       "requires": {
         "js-yaml": "3.13.1",
@@ -10299,24 +10550,24 @@
     },
     "vlq": {
       "version": "0.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vlq/-/vlq-0.2.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vlq/-/vlq-0.2.3.tgz",
       "integrity": "sha1-jz5DKM9jsVQMDWfhsneDhviXWyY=",
       "dev": true
     },
     "vscode-uri": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vscode-uri/-/vscode-uri-1.0.6.tgz",
       "integrity": "sha1-a48UGwu8RK17B+lPgvForHYIrU0=",
       "dev": true
     },
     "vue": {
       "version": "2.6.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vue/-/vue-2.6.10.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vue/-/vue-2.6.10.tgz",
       "integrity": "sha1-pysaQqTYKnIepDjRtr9V5mGVxjc="
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wbuf/-/wbuf-1.7.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
       "dev": true,
       "requires": {
@@ -10325,7 +10576,7 @@
     },
     "wct-browser-legacy": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-browser-legacy/-/wct-browser-legacy-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-browser-legacy/-/wct-browser-legacy-1.0.2.tgz",
       "integrity": "sha1-a+ORdL034pAwKNPb0ikvnE7Fl2c=",
       "dev": true,
       "requires": {
@@ -10345,16 +10596,16 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
       }
     },
     "wct-local": {
-      "version": "2.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-local/-/wct-local-2.1.4.tgz",
-      "integrity": "sha1-tJuZLeMrnZ6bgd5YXXrRub9jMfY=",
+      "version": "2.1.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-local/-/wct-local-2.1.5.tgz",
+      "integrity": "sha1-95hnU+OtmjXTkXipmJNQUjVh//E=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -10372,7 +10623,7 @@
     },
     "wct-sauce": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-sauce/-/wct-sauce-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-sauce/-/wct-sauce-2.1.0.tgz",
       "integrity": "sha1-Z9C+NGqru8KDhOjRQ7jTynundMA=",
       "dev": true,
       "optional": true,
@@ -10387,40 +10638,36 @@
       }
     },
     "wd": {
-      "version": "1.11.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wd/-/wd-1.11.2.tgz",
-      "integrity": "sha1-vKKkfOmoZnEOLbjIAjhdBryWREQ=",
+      "version": "1.11.3",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wd/-/wd-1.11.3.tgz",
+      "integrity": "sha1-2yKIY+FWSODBRm30WyY/wwRw28Q=",
       "dev": true,
       "requires": {
-        "archiver": "2.1.1",
-        "async": "2.0.1",
-        "lodash": "4.17.11",
+        "archiver": "^3.0.0",
+        "async": "^2.0.0",
+        "fancy-log": "^1.3.3",
+        "gulp-mocha": "^6.0.0",
+        "lodash": "^4.0.0",
         "mkdirp": "^0.5.1",
-        "q": "1.4.1",
+        "q": "^1.5.1",
         "request": "2.88.0",
-        "vargs": "0.1.0"
+        "vargs": "^0.1.0"
       },
       "dependencies": {
         "async": {
-          "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.0.1.tgz",
-          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "version": "2.6.3",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
           "dev": true,
           "requires": {
-            "lodash": "^4.8.0"
+            "lodash": "^4.17.14"
           }
-        },
-        "q": {
-          "version": "1.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/q/-/q-1.4.1.tgz",
-          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
-          "dev": true
         }
       }
     },
     "web-component-tester": {
       "version": "6.9.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/web-component-tester/-/web-component-tester-6.9.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/web-component-tester/-/web-component-tester-6.9.2.tgz",
       "integrity": "sha1-QKe4JPLPPLxDBVUr38M1eXfe1Io=",
       "dev": true,
       "requires": {
@@ -10456,42 +10703,42 @@
       "dependencies": {
         "@polymer/test-fixture": {
           "version": "0.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
           "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
           "dev": true
         },
         "@webcomponents/webcomponentsjs": {
           "version": "1.3.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz",
           "integrity": "sha1-W7gqDTIQyDa9RiPhOkqTFFy53Cc=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "async": {
-          "version": "2.6.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.2.tgz",
-          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
+          "version": "2.6.3",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
           },
           "dependencies": {
             "lodash": {
-              "version": "4.17.11",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-4.17.11.tgz",
-              "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+              "version": "4.17.15",
+              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-4.17.15.tgz",
+              "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
               "dev": true
             }
           }
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10504,7 +10751,7 @@
         },
         "formatio": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/formatio/-/formatio-1.2.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/formatio/-/formatio-1.2.0.tgz",
           "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
           "dev": true,
           "requires": {
@@ -10513,19 +10760,19 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "lolex": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-1.6.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-1.6.0.tgz",
           "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
           "dev": true
         },
         "path-to-regexp": {
           "version": "1.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
           "dev": true,
           "requires": {
@@ -10534,13 +10781,13 @@
         },
         "samsam": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/samsam/-/samsam-1.3.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/samsam/-/samsam-1.3.0.tgz",
           "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
           "dev": true
         },
         "sinon": {
           "version": "2.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-2.4.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-2.4.1.tgz",
           "integrity": "sha1-Ah/WS1TLd9nS+w1Dze3652KcOjY=",
           "dev": true,
           "requires": {
@@ -10556,13 +10803,13 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "type-detect": {
           "version": "4.0.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-4.0.8.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-4.0.8.tgz",
           "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
           "dev": true
         }
@@ -10570,7 +10817,7 @@
     },
     "webfonts-generator": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webfonts-generator/-/webfonts-generator-0.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webfonts-generator/-/webfonts-generator-0.4.0.tgz",
       "integrity": "sha1-X4n8gccWDm4Mu8m3OH5CpYUf2kY=",
       "requires": {
         "handlebars": "^4.0.5",
@@ -10587,13 +10834,13 @@
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
       "dev": true
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "dev": true,
       "requires": {
@@ -10604,7 +10851,7 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which/-/which-1.3.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which/-/which-1.3.1.tgz",
       "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "requires": {
         "isexe": "^2.0.0"
@@ -10612,13 +10859,13 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "wide-align": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wide-align/-/wide-align-1.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
       "requires": {
         "string-width": "^1.0.2 || 2"
@@ -10626,7 +10873,7 @@
     },
     "widest-line": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
       "integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
       "dev": true,
       "requires": {
@@ -10635,19 +10882,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -10657,7 +10904,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -10668,7 +10915,7 @@
     },
     "winston": {
       "version": "3.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/winston/-/winston-3.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/winston/-/winston-3.2.1.tgz",
       "integrity": "sha1-YwYTd5dsc1hAKL4kkKGEYFX3fwc=",
       "dev": true,
       "requires": {
@@ -10684,17 +10931,17 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.2.tgz",
-          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
+          "version": "2.6.3",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
           }
         },
         "logform": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/logform/-/logform-2.1.2.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/logform/-/logform-2.1.2.tgz",
           "integrity": "sha1-lXFV6+tnoTFkBpglzmfdtbst02A=",
           "dev": true,
           "requires": {
@@ -10707,7 +10954,7 @@
         },
         "readable-stream": {
           "version": "3.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.4.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha1-pRwmdUZY4KPCHb9ZFjvUW6b0R/w=",
           "dev": true,
           "requires": {
@@ -10718,7 +10965,7 @@
         },
         "string_decoder": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.2.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.2.0.tgz",
           "integrity": "sha1-/obnOLGVRK/nBGkkOyoe6SQOro0=",
           "dev": true,
           "requires": {
@@ -10729,7 +10976,7 @@
     },
     "winston-transport": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/winston-transport/-/winston-transport-4.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/winston-transport/-/winston-transport-4.3.0.tgz",
       "integrity": "sha1-32jAwgJILESNm0cxPAcwTC18LGY=",
       "dev": true,
       "requires": {
@@ -10739,12 +10986,12 @@
     },
     "wordwrap": {
       "version": "0.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-0.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wordwrapjs": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
       "integrity": "sha1-yUw3KJTK3G/rGma/9k4dmvksXR4=",
       "dev": true,
       "requires": {
@@ -10754,7 +11001,7 @@
       "dependencies": {
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
@@ -10762,7 +11009,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -10772,12 +11019,12 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
       "dev": true,
       "requires": {
@@ -10788,7 +11035,7 @@
     },
     "ws": {
       "version": "6.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ws/-/ws-6.1.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ws/-/ws-6.1.4.tgz",
       "integrity": "sha1-W1yIAK+rkl6UzLKdFTyNAsF3bvk=",
       "dev": true,
       "requires": {
@@ -10797,49 +11044,49 @@
     },
     "xdg-basedir": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
     "xmlbuilder": {
       "version": "8.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
       "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
       "dev": true,
       "optional": true
     },
     "xmldom": {
       "version": "0.1.27",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmldom/-/xmldom-0.1.27.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "version": "4.0.2",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     },
     "y18n": {
       "version": "3.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/y18n/-/y18n-3.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha1-kLhpk07W6HERXqL/WLA/RyTtLXc=",
       "dev": true,
       "requires": {
@@ -10859,19 +11106,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -10881,7 +11128,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -10892,7 +11139,7 @@
     },
     "yargs-parser": {
       "version": "9.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-9.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-9.0.2.tgz",
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {
@@ -10901,7 +11148,7 @@
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yauzl/-/yauzl-2.10.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "optional": true,
@@ -10912,20 +11159,41 @@
     },
     "yeast": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yeast/-/yeast-0.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     },
     "zip-stream": {
-      "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/zip-stream/-/zip-stream-1.2.0.tgz",
-      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "version": "2.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/zip-stream/-/zip-stream-2.1.0.tgz",
+      "integrity": "sha1-T5Qka2Q0FTa4Yxi9VWZUJ4gStyY=",
       "dev": true,
       "requires": {
-        "archiver-utils": "^1.3.0",
-        "compress-commons": "^1.2.0",
-        "lodash": "^4.8.0",
-        "readable-stream": "^2.0.0"
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^2.0.0",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha1-pRwmdUZY4KPCHb9ZFjvUW6b0R/w=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha1-/obnOLGVRK/nBGkkOyoe6SQOro0=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "np": "3.0.4",
     "replace": "1.0.0",
     "uglify-es": "github:mishoo/UglifyJS2#harmony",
-    "vl-ui-util": "1.1.3",
+    "vl-ui-util": "^1.2.3",
     "wct-browser-legacy": "1.0.2",
     "web-component-tester": "6.9.2"
   }

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -19,10 +19,17 @@ services:
       - HUB_PORT_4444_TCP_PORT=4444
   tests:
     image: ${DOCKER_REGISTRY}node:12
+    command: bash -c "cp -R /data/. /workdir && npm install && npm run test"
     depends_on:
       - selenium-hub
       - selenium-chrome
       - selenium-firefox
+    environment: 
+      - http_proxy=${http_proxy}
+      - https_proxy=${https_proxy}
+      - no_proxy=${no_proxy},selenium-hub,host
+    extra_hosts:
+      - "repository.milieuinfo.be:${REPOSITORY_FIXED_IP}"
     working_dir: /workdir
     volumes:
       - ${HOME:-.}/.npmrc:/root/.npmrc:ro
@@ -30,7 +37,6 @@ services:
       - ${HOME:-.}/.git-credentials:/root/.git-credentials:ro
       - ..:/data:ro
       - ./wct.docker.conf.json:/workdir/wct.conf.json:ro
-    command: bash -c "cp -R /data/. /workdir && npm install && npm run test"
 networks:
   build-network:
     driver: bridge


### PR DESCRIPTION
- Upgrade naar vl-ui-util 1.2.3
- Carret toegevoegd aan vl-ui-util versie
- `npm install` van de vl-ui-util 1.2.3 gedaan zodat proxy changes mee in docker-compose zitten